### PR TITLE
fixed if statements for skip_tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#63](https://github.com/nf-core/demultiplex/pull/63) Fix MultiQC report inputs, fixes MultiQC report is empty #64
 - [#67](https://github.com/nf-core/demultiplex/pull/67) Enable instititutional configs
+- [#83](https://github.com/nf-core/demultiplex/pull/83) Fix skip_tools
 
 ## v1.0.0 - 2022-10-06
 

--- a/tests/pipeline/default/skip_tools.nf.test
+++ b/tests/pipeline/default/skip_tools.nf.test
@@ -1,0 +1,31 @@
+nextflow_pipeline {
+
+    name "Test skips"
+    script "main.nf"
+
+    test("Should skip trimming") {
+
+        when {
+            params {
+                input = "$baseDir/assets/inputs/flowcell_input.csv"
+                demultiplexer = 'bclconvert'
+                trim_fastq  = false
+                outdir = "$outputDir"
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert workflow.trace.succeeded().size() == 7
+
+            assert snapshot(
+                path("$outputDir/220422_M11111_0222_000000000-K9H97/Sample1_S1_L001_R1_001.fastq.gz"),
+                path("$outputDir/220422_M11111_0222_000000000-K9H97/Sample1_S1_L001_R1_001.fastq.gz.md5"),
+                path("$outputDir/220422_M11111_0222_000000000-K9H97/Undetermined_S0_L001_R1_001.fastq.gz"),
+                path("$outputDir/220422_M11111_0222_000000000-K9H97/L001/Reports/").list(),
+            ).match()
+        }
+
+    }
+
+}

--- a/tests/pipeline/default/skip_tools.nf.test
+++ b/tests/pipeline/default/skip_tools.nf.test
@@ -54,6 +54,32 @@ nextflow_pipeline {
 
     }
 
+    test("Should skip fastqc") {
+
+        when {
+            params {
+                input = "$baseDir/assets/inputs/flowcell_input.csv"
+                demultiplexer = 'bclconvert'
+                skip_tools = "fastqc"
+                outdir = "$outputDir"
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert workflow.trace.succeeded().size() == 7
+
+            assert snapshot(
+                path("$outputDir/220422_M11111_0222_000000000-K9H97/Sample1_S1_L001_R1_001.fastq.gz"),
+                // FIXME
+                // path("$outputDir/220422_M11111_0222_000000000-K9H97/Sample1_S1_L001_R1_001.fastq.gz.md5"),
+                path("$outputDir/220422_M11111_0222_000000000-K9H97/Undetermined_S0_L001_R1_001.fastq.gz"),
+                path("$outputDir/220422_M11111_0222_000000000-K9H97/L001/Reports/").list(),
+            ).match()
+        }
+
+    }
+
     test("Should skip fastp and fastqc") {
 
         when {

--- a/tests/pipeline/default/skip_tools.nf.test
+++ b/tests/pipeline/default/skip_tools.nf.test
@@ -28,4 +28,29 @@ nextflow_pipeline {
 
     }
 
+    test("Should skip fastp") {
+
+        when {
+            params {
+                input = "$baseDir/assets/inputs/flowcell_input.csv"
+                demultiplexer = 'bclconvert'
+                skip_tools = "fastp"
+                outdir = "$outputDir"
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert workflow.trace.succeeded().size() == 6
+
+            assert snapshot(
+                path("$outputDir/220422_M11111_0222_000000000-K9H97/Sample1_S1_L001_R1_001.fastq.gz"),
+                path("$outputDir/220422_M11111_0222_000000000-K9H97/Sample1_S1_L001_R1_001.fastq.gz.md5"),
+                path("$outputDir/220422_M11111_0222_000000000-K9H97/Undetermined_S0_L001_R1_001.fastq.gz"),
+                path("$outputDir/220422_M11111_0222_000000000-K9H97/L001/Reports/").list(),
+            ).match()
+        }
+
+    }
+
 }

--- a/tests/pipeline/default/skip_tools.nf.test
+++ b/tests/pipeline/default/skip_tools.nf.test
@@ -1,4 +1,5 @@
 nextflow_pipeline {
+    // https://github.com/nf-core/demultiplex/issues/82
 
     name "Test skips"
     script "main.nf"
@@ -35,6 +36,31 @@ nextflow_pipeline {
                 input = "$baseDir/assets/inputs/flowcell_input.csv"
                 demultiplexer = 'bclconvert'
                 skip_tools = "fastp"
+                outdir = "$outputDir"
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert workflow.trace.succeeded().size() == 6
+
+            assert snapshot(
+                path("$outputDir/220422_M11111_0222_000000000-K9H97/Sample1_S1_L001_R1_001.fastq.gz"),
+                path("$outputDir/220422_M11111_0222_000000000-K9H97/Sample1_S1_L001_R1_001.fastq.gz.md5"),
+                path("$outputDir/220422_M11111_0222_000000000-K9H97/Undetermined_S0_L001_R1_001.fastq.gz"),
+                path("$outputDir/220422_M11111_0222_000000000-K9H97/L001/Reports/").list(),
+            ).match()
+        }
+
+    }
+
+    test("Should skip fastp and fastqc") {
+
+        when {
+            params {
+                input = "$baseDir/assets/inputs/flowcell_input.csv"
+                demultiplexer = 'bclconvert'
+                skip_tools = "fastp,fastqc"
                 outdir = "$outputDir"
             }
         }

--- a/tests/pipeline/default/skip_tools.nf.test.snap
+++ b/tests/pipeline/default/skip_tools.nf.test.snap
@@ -1,0 +1,24 @@
+{
+    "Should skip trimming": {
+        "content": [
+            "Sample1_S1_L001_R1_001.fastq.gz:md5,0a0341e2990b4fa1d9ad4b4c603144c1",
+            "Sample1_S1_L001_R1_001.fastq.gz.md5:md5,c547a3c03e7c60c871d78018ec5d933f",
+            "Undetermined_S0_L001_R1_001.fastq.gz:md5,febef808ae5397ea4ee7ee40e5fd39e0",
+            [
+                "Adapter_Cycle_Metrics.csv:md5,5a0c88793b4a0885fe3dda16609b576e",
+                "Adapter_Metrics.csv:md5,989240b8840b2169ac1061f952c90f6c",
+                "Demultiplex_Stats.csv:md5,93949a8cd96f907d83e0808c1ec2a04b",
+                "Demultiplex_Tile_Stats.csv:md5,83120160b0f22a1303fa1db31c19f6e9",
+                "IndexMetricsOut.bin:md5,9e688c58a5487b8eaf69c9e1005ad0bf",
+                "Index_Hopping_Counts.csv:md5,1059369e375fd8f8423c0f6c934be978",
+                "Quality_Metrics.csv:md5,6614accb1bb414fe312b17b81f5521f7",
+                "Quality_Tile_Metrics.csv:md5,cdc89fd2962bdd4a24f71e186112118a",
+                "RunInfo.xml:md5,03038959f4dd181c86bc97ae71fe270a",
+                "SampleSheet.csv:md5,ee5db2e12754e069998b0a96e535238c",
+                "Top_Unknown_Barcodes.csv:md5,2e2faba761137f228e56bd3428453ccc",
+                "fastq_list.csv:md5,05bc84f51840f5754cfb8381b36f2cb0"
+            ]
+        ],
+        "timestamp": "2023-01-18T22:31:23+0000"
+    }
+}

--- a/tests/pipeline/default/skip_tools.nf.test.snap
+++ b/tests/pipeline/default/skip_tools.nf.test.snap
@@ -1,4 +1,26 @@
 {
+    "Should skip fastp and fastqc": {
+        "content": [
+            "Sample1_S1_L001_R1_001.fastq.gz:md5,0a0341e2990b4fa1d9ad4b4c603144c1",
+            "Sample1_S1_L001_R1_001.fastq.gz.md5:md5,c547a3c03e7c60c871d78018ec5d933f",
+            "Undetermined_S0_L001_R1_001.fastq.gz:md5,febef808ae5397ea4ee7ee40e5fd39e0",
+            [
+                "Adapter_Cycle_Metrics.csv:md5,5a0c88793b4a0885fe3dda16609b576e",
+                "Adapter_Metrics.csv:md5,989240b8840b2169ac1061f952c90f6c",
+                "Demultiplex_Stats.csv:md5,93949a8cd96f907d83e0808c1ec2a04b",
+                "Demultiplex_Tile_Stats.csv:md5,83120160b0f22a1303fa1db31c19f6e9",
+                "IndexMetricsOut.bin:md5,9e688c58a5487b8eaf69c9e1005ad0bf",
+                "Index_Hopping_Counts.csv:md5,1059369e375fd8f8423c0f6c934be978",
+                "Quality_Metrics.csv:md5,6614accb1bb414fe312b17b81f5521f7",
+                "Quality_Tile_Metrics.csv:md5,cdc89fd2962bdd4a24f71e186112118a",
+                "RunInfo.xml:md5,03038959f4dd181c86bc97ae71fe270a",
+                "SampleSheet.csv:md5,ee5db2e12754e069998b0a96e535238c",
+                "Top_Unknown_Barcodes.csv:md5,2e2faba761137f228e56bd3428453ccc",
+                "fastq_list.csv:md5,05bc84f51840f5754cfb8381b36f2cb0"
+            ]
+        ],
+        "timestamp": "2023-01-18T22:46:32+0000"
+    },
     "Should skip trimming": {
         "content": [
             "Sample1_S1_L001_R1_001.fastq.gz:md5,0a0341e2990b4fa1d9ad4b4c603144c1",

--- a/tests/pipeline/default/skip_tools.nf.test.snap
+++ b/tests/pipeline/default/skip_tools.nf.test.snap
@@ -19,6 +19,28 @@
                 "fastq_list.csv:md5,05bc84f51840f5754cfb8381b36f2cb0"
             ]
         ],
-        "timestamp": "2023-01-18T22:31:23+0000"
+        "timestamp": "2023-01-18T22:42:00+0000"
+    },
+    "Should skip fastp": {
+        "content": [
+            "Sample1_S1_L001_R1_001.fastq.gz:md5,0a0341e2990b4fa1d9ad4b4c603144c1",
+            "Sample1_S1_L001_R1_001.fastq.gz.md5:md5,c547a3c03e7c60c871d78018ec5d933f",
+            "Undetermined_S0_L001_R1_001.fastq.gz:md5,febef808ae5397ea4ee7ee40e5fd39e0",
+            [
+                "Adapter_Cycle_Metrics.csv:md5,5a0c88793b4a0885fe3dda16609b576e",
+                "Adapter_Metrics.csv:md5,989240b8840b2169ac1061f952c90f6c",
+                "Demultiplex_Stats.csv:md5,93949a8cd96f907d83e0808c1ec2a04b",
+                "Demultiplex_Tile_Stats.csv:md5,83120160b0f22a1303fa1db31c19f6e9",
+                "IndexMetricsOut.bin:md5,9e688c58a5487b8eaf69c9e1005ad0bf",
+                "Index_Hopping_Counts.csv:md5,1059369e375fd8f8423c0f6c934be978",
+                "Quality_Metrics.csv:md5,6614accb1bb414fe312b17b81f5521f7",
+                "Quality_Tile_Metrics.csv:md5,cdc89fd2962bdd4a24f71e186112118a",
+                "RunInfo.xml:md5,03038959f4dd181c86bc97ae71fe270a",
+                "SampleSheet.csv:md5,ee5db2e12754e069998b0a96e535238c",
+                "Top_Unknown_Barcodes.csv:md5,2e2faba761137f228e56bd3428453ccc",
+                "fastq_list.csv:md5,05bc84f51840f5754cfb8381b36f2cb0"
+            ]
+        ],
+        "timestamp": "2023-01-18T22:42:00+0000"
     }
 }

--- a/tests/pipeline/default/skip_tools.nf.test.snap
+++ b/tests/pipeline/default/skip_tools.nf.test.snap
@@ -64,5 +64,26 @@
             ]
         ],
         "timestamp": "2023-01-18T22:42:00+0000"
+    },
+    "Should skip fastqc": {
+        "content": [
+            "Sample1_S1_L001_R1_001.fastq.gz:md5,0a0341e2990b4fa1d9ad4b4c603144c1",
+            "Undetermined_S0_L001_R1_001.fastq.gz:md5,febef808ae5397ea4ee7ee40e5fd39e0",
+            [
+                "Adapter_Cycle_Metrics.csv:md5,5a0c88793b4a0885fe3dda16609b576e",
+                "Adapter_Metrics.csv:md5,989240b8840b2169ac1061f952c90f6c",
+                "Demultiplex_Stats.csv:md5,93949a8cd96f907d83e0808c1ec2a04b",
+                "Demultiplex_Tile_Stats.csv:md5,83120160b0f22a1303fa1db31c19f6e9",
+                "IndexMetricsOut.bin:md5,9e688c58a5487b8eaf69c9e1005ad0bf",
+                "Index_Hopping_Counts.csv:md5,1059369e375fd8f8423c0f6c934be978",
+                "Quality_Metrics.csv:md5,6614accb1bb414fe312b17b81f5521f7",
+                "Quality_Tile_Metrics.csv:md5,cdc89fd2962bdd4a24f71e186112118a",
+                "RunInfo.xml:md5,03038959f4dd181c86bc97ae71fe270a",
+                "SampleSheet.csv:md5,ee5db2e12754e069998b0a96e535238c",
+                "Top_Unknown_Barcodes.csv:md5,2e2faba761137f228e56bd3428453ccc",
+                "fastq_list.csv:md5,05bc84f51840f5754cfb8381b36f2cb0"
+            ]
+        ],
+        "timestamp": "2023-01-18T22:58:43+0000"
     }
 }


### PR DESCRIPTION
By default `fastp` and `falco` are always skipped even without providing `skip_tools` options. After this change, `skip_tools` worked as expected i.e: `--skip_tools fastp`.  

However there is still a problem with `--trim_fastq true` 

```
No such variable: Exception evaluating property 'fastq' for nextflow.script.ChannelOut, Reason: groovy.lang.MissingPropertyException: No such property: fastq for class: groovyx.gpars.dataflow.DataflowBroadcast
 -- Check script './workflows/demultiplex.nf' at line: 155 
```

Problematic lines 
```
 if (trim_fastq) {
                ch_fastq_to_qc = FASTP.out.fastq
            }
```

This pertains to issue #82  