### PR TITLE
Add fqtk as a demultiplexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [dev]
 
 - [#91](https://github.com/nf-core/demultiplex/pull/91) Add sgdemux
+- [#99](https://github.com/nf-core/demultiplex/pull/99) Add fqtk
 
 ## v1.1.0 - 2023-01-23
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 1. Illumina (via `bcl2fastq` or `bclconvert`)
 2. Element Biosciences (via `bases2fastq`)
 3. Singular Genomics (via [`sgdemux`](https://github.com/Singular-Genomics/singular-demux))
+4. FASTQ files with user supplied read structures (via ['fqtk'](https://github.com/fulcrumgenomics/fqtk))
 
 The pipeline is built using [Nextflow](https://www.nextflow.io), a workflow tool to run tasks across multiple compute infrastructures in a very portable manner. It uses Docker/Singularity containers making installation trivial and results highly reproducible. The [Nextflow DSL2](https://www.nextflow.io/docs/latest/dsl2.html) implementation of this pipeline uses one container per process which makes it much easier to maintain and update software dependencies. Where possible, these processes have been submitted to and installed from [nf-core/modules](https://github.com/nf-core/modules) in order to make them available to all nf-core pipelines, and to everyone within the Nextflow community!
 
@@ -33,6 +34,7 @@ On release, automated continuous integration tests run the pipeline on a full-si
 - [bases2fastq](#bases2fastq) - converting bases files to fastq, and demultiplexing (CONDITIONAL)
 - [bcl2fastq](#bcl2fastq) - converting bcl files to fastq, and demultiplexing (CONDITIONAL)
 - [sgdemux](#sgdemux) - demultiplexing bgzipped fastq files produced by Singular Genomics (CONDITIONAL)
+- [fqtk](#fqtk) - a toolkit for working with FASTQ files, written in Rust (CONDITIONAL)
 
 2. [fastp](#fastp) - Adapter and quality trimming
 3. [Falco](#falco) - Raw read QC

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 1. Illumina (via `bcl2fastq` or `bclconvert`)
 2. Element Biosciences (via `bases2fastq`)
 3. Singular Genomics (via [`sgdemux`](https://github.com/Singular-Genomics/singular-demux))
-4. FASTQ files with user supplied read structures (via ['fqtk'](https://github.com/fulcrumgenomics/fqtk))
+4. FASTQ files with user supplied read structures (via [`fqtk`](https://github.com/fulcrumgenomics/fqtk))
 
 The pipeline is built using [Nextflow](https://www.nextflow.io), a workflow tool to run tasks across multiple compute infrastructures in a very portable manner. It uses Docker/Singularity containers making installation trivial and results highly reproducible. The [Nextflow DSL2](https://www.nextflow.io/docs/latest/dsl2.html) implementation of this pipeline uses one container per process which makes it much easier to maintain and update software dependencies. Where possible, these processes have been submitted to and installed from [nf-core/modules](https://github.com/nf-core/modules) in order to make them available to all nf-core pipelines, and to everyone within the Nextflow community!
 

--- a/assets/inputs/fqtk-samplesheet.csv
+++ b/assets/inputs/fqtk-samplesheet.csv
@@ -1,3 +1,2 @@
 id,samplesheet,lane,flowcell,per_flowcell_manifest
-test,https://github.com/nf-core/test-datasets/raw/demultiplex/testdata/sim-data/fqtk_samplesheet.csv,,https://github.com/nf-core/test-datasets/raw/demultiplex/testdata/sim-data/per_flowcell_manifest.csv
-
+test,https://github.com/nf-core/test-datasets/raw/demultiplex/testdata/sim-data/fqtk_samplesheet.csv,,https://github.com/nf-core/test-datasets/raw/demultiplex/testdata/sim-data/fastq.tar.gz,https://github.com/nf-core/test-datasets/raw/demultiplex/testdata/sim-data/per_flowcell_manifest.csv

--- a/assets/inputs/fqtk-samplesheet.csv
+++ b/assets/inputs/fqtk-samplesheet.csv
@@ -1,0 +1,3 @@
+id,samplesheet,lane,flowcell,per_flowcell_manifest
+test,https://github.com/nf-core/test-datasets/raw/demultiplex/testdata/sim-data/fqtk_samplesheet.csv,,https://github.com/nf-core/test-datasets/raw/demultiplex/testdata/sim-data/per_flowcell_manifest.csv
+

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -172,5 +172,16 @@ process {
             ],
         ]
     }
+ 
+   withName: FQTK {
+        publishDir = [
+            [
+                path: { "${params.outdir}/${meta.id}/" },
+                mode: params.publish_dir_mode,
+                pattern: "output/*.{txt, fq.gz}",
+                saveAs: { filename -> filename.minus("output/") }
+            ],
+        ]
+    }
 }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -172,8 +172,8 @@ process {
             ],
         ]
     }
- 
-   withName: FQTK {
+
+    withName: FQTK {
         publishDir = [
             [
                 path: { "${params.outdir}/${meta.id}/" },

--- a/conf/test_fqtk.config
+++ b/conf/test_fqtk.config
@@ -1,0 +1,25 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Nextflow config file for running minimal tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Defines input files and everything required to run a fast and simple pipeline test.
+
+    Use as follows:
+        nextflow run nf-core/demultiplex -profile test_fqtk,<docker/singularity> --outdir <OUTDIR>
+
+----------------------------------------------------------------------------------------
+*/
+
+params {
+    config_profile_name        = 'Test fqtk profile'
+    config_profile_description = 'Minimal test dataset to check pipeline function'
+
+    // Limit resources so that this can run on GitHub Actions
+    max_cpus   = 2
+    max_memory = '6.GB'
+    max_time   = '1.h'
+
+    // Input data
+    input = "${projectDir}/assets/inputs/fqtk-samplesheet.csv"
+    demultiplexer = 'fqtk'
+}

--- a/docs/output.md
+++ b/docs/output.md
@@ -14,6 +14,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 - [bases2fastq](#bases2fastq) - converting bases files to fastq, and demultiplexing (CONDITIONAL)
 - [bcl2fastq](#bcl2fastq) - converting bcl files to fastq, and demultiplexing (CONDITIONAL)
 - [sgdemux](#sgdemux) - demultiplexing bgzipped fastq files produced by Singular Genomics (CONDITIONAL)
+- [fqtk](#fqtk) - demultiplexing fastq files (CONDITIONAL)
 - [fastp](#fastp) - Adapter and quality trimming
 - [Falco](#falco) - Raw read QC
 - [md5sum](#md5sum) - Creates an MD5 (128-bit) checksum of every fastq.
@@ -67,7 +68,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 | File                             | Directory                          | Description                                                                                 |
 | :------------------------------- | :--------------------------------- | :------------------------------------------------------------------------------------------ |
 | Execution logs                   | <OUTDIR>/pipeline_info             | Log files for the nextflow workflow                                                         |
-| `software_versions/yml`          | <OUTDIR>/pipeline_info             | Log file with software versions                                                             |
+| `software_versions.yml`          | <OUTDIR>/pipeline_info             | Log file with software versions                                                             |
 | FASTQ                            | <OUTDIR>/<id>                      | Demultiplexed fastq.gz files                                                                |
 | `metrics.csv`                    | <OUTDIR>/<id>                      | Summary stats across run: control_reads_omitted, failing_reads_omitted, and total_templates |
 | `most_frequent_unmatched.tsv`    | <OUTDIR>/<id>                      | Counts for the most prevalent unmatched barcode: barcode, count                             |
@@ -77,6 +78,26 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 | Fastqc summary stats             | <OUTDIR>/<id>/\*fastqc_data.txt    | Per base quality summary, for each demultiplexed fastq file                                 |
 | Fastq summary html               | <OUTDIR>/<id>/\*fastqc_report.html | Interactive html link for fastqc summary stats                                              |
 | Md5Sum                           | <OUTDIR>/<id>/\*.md5               | Md5Sums for each demultiplexed fastq file                                                   |
+
+</details>
+
+### fqtk
+
+[fqtk](https://github.com/fulcrumgenomics/fqtk) A toolkit for working with FASTQ files, written in Rust.
+
+<details markdown="1">
+<summary>Output files</summary>
+
+| File                       | Directory                          | Description                                                 |
+| :------------------------- | :--------------------------------- | :---------------------------------------------------------- |
+| Execution logs             | <OUTDIR>/pipeline_info             | Log files for the nextflow workflow                         |
+| `software_versions.yml`    | <OUTDIR>/pipeline_info             | Log file with software versions                             |
+| FASTQ                      | <OUTDIR>/<id>                      | Demultiplexed fastq.gz files                                |
+| `demux-metrics.txt`        | <OUTDIR>/<id>                      | Summary stats across run                                    |
+| `unmatched_<1/2>.fastq.gz` | <OUTDIR>/<id>                      | Unmatched R1 and R2 records                                 |
+| Fastqc summary stats       | <OUTDIR>/<id>/\*fastqc_data.txt    | Per base quality summary, for each demultiplexed fastq file |
+| Fastq summary html         | <OUTDIR>/<id>/\*fastqc_report.html | Interactive html link for fastqc summary stats              |
+| Md5Sum                     | <OUTDIR>/<id>/\*.md5               | Md5Sums for each demultiplexed fastq file                   |
 
 </details>
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,6 +10,8 @@
 
 You will need to create a samplesheet with information about the samples you would like to analyse before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 3 columns, and a header row as shown in the examples below.
 
+When using the demultiplexer fqtk, the samplesheet must contain an additional column `per_flowcell_manifest`. The column `per_flowcell_manifest` must contain two headers `fastq` and `read_structure`. As shown in the [example](https://github.com/fulcrumgenomics/nf-core-test-datasets/blob/fqtk/testdata/sim-data/per_flowcell_manifest.csv) provided each row must contain one fastq file name and the correlating read structure.
+
 ```bash
 --input '[path to samplesheet file]'
 ```
@@ -32,6 +34,28 @@ DDMMYY_SERIAL_NUMBER_FC3,/path/to/SampleSheet3.csv,3,/path/to/sequencer/output3
 | `run_dir`     | Full path to the Illumina sequencer output directory or a `tar.gz` file containing the contents of said directory |
 
 An [example samplesheet](../assets/inputs/flowcell_input.csv) has been provided with the pipeline.
+
+Note `run_dir` must lead to a `tar.gz` for compatability with the demultiplexers sgdemux and fqtk
+
+Please see the following examples to format `SampleSheet.csv` for [sgdemux](https://github.com/nf-core/test-datasets/blob/demultiplex/testdata/sim-data/out.sample_meta.csv) and [fqtk](https://github.com/fulcrumgenomics/nf-core-test-datasets/raw/fqtk/testdata/sim-data/fqtk_samplesheet.csv)
+
+### Samplesheet for fqtk
+
+```console
+id,samplesheet,lane,flowcell,per_flowcell_manifest
+DDMMYY_SERIAL_NUMBER_FC,/path/to/SampleSheet.csv,1,/path/to/sequencer/output,/path/to/flowcell/manifest.csv
+DDMMYY_SERIAL_NUMBER_FC,/path/to/SampleSheet1.csv,2,/path/to/sequencer/output,/path/to/flowcell/manifest1.csv
+DDMMYY_SERIAL_NUMBER_FC2,/path/to/SampleSheet2.csv,1,/path/to/sequencer/output2,/path/to/flowcell/manifest2.csv
+DDMMYY_SERIAL_NUMBER_FC3,/path/to/SampleSheet3.csv,3,/path/to/sequencer/output3,/path/to/flowcell/manifest3.csv
+```
+
+| Column                  | Description                                                                                                       |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `id`                    | flowcell id                                                                                                       |
+| `samplesheet`           | Full path to the `SampleSheet.csv` file containing the sample information and indexes                             |
+| `lane`                  | Optional lane number. When a lane number is provided, only the given lane will be demultiplexed                   |
+| `run_dir`               | Full path to the Illumina sequencer output directory or a `tar.gz` file containing the contents of said directory |
+| `per_flowcell_manifest` | Full path to the flowcell manifest, containing the fastq file names and read structures                           |
 
 ## Running the pipeline
 

--- a/modules.json
+++ b/modules.json
@@ -35,6 +35,11 @@
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
                         "installed_by": ["modules"]
                     },
+                    "fqtk": {
+                        "branch": "master",
+                        "git_sha": "c3e177f0cd1ad539d5184a7bcc22f51605d897d1",
+                        "installed_by": ["modules"]
+                    },
                     "md5sum": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",

--- a/modules/local/csv2tsv.nf
+++ b/modules/local/csv2tsv.nf
@@ -1,0 +1,20 @@
+process CSV2TSV {
+    tag "$meta.id"
+    label 'process_medium'
+
+    input:
+    tuple val(meta), path(sample_sheet), val(fastq_readstructure_pairs)
+    // fastq_readstructure_pairs example:
+    // [[<fastq name: string>, <read structure: string>, <path to fastqs: path>], [example_R1.fastq.gz, 150T, ./work/98/30bc..78y/fastqs/]]
+
+    output:
+    tuple val(meta), path('samplesheet.tsv'), val(fastq_readstructure_pairs), emit: ch_output
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    """
+    sed 's/,/\t/g' ${sample_sheet} > samplesheet.tsv
+    """
+}

--- a/modules/nf-core/fqtk/main.nf
+++ b/modules/nf-core/fqtk/main.nf
@@ -1,0 +1,48 @@
+process FQTK {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "bioconda::fqtk=0.2.1"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/fqtk:0.2.1--h9f5acd7_0' :
+        'quay.io/biocontainers/fqtk:0.2.1--h9f5acd7_0' }"
+
+    input:
+    tuple val(meta), path(sample_sheet), val(fastq_readstructure_pairs)
+    // fastq_readstructure_pairs example:
+    // [[<fastq name: string>, <read structure: string>, <path to fastqs: path>], [example_R1.fastq.gz, 150T, ./work/98/30bc..78y/fastqs/]]
+
+    output:
+    // Demultiplexed file name changes depending on the arg '--output-types'
+    tuple val(meta), path('output/*.fq.gz')                         , emit: sample_fastq
+    tuple val(meta), path('output/demux-metrics.txt')               , emit: metrics
+    tuple val(meta), path('output/unmatched*.fq.gz')                , emit: most_frequent_unmatched
+    path "versions.yml"                                             , emit: versions
+
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    // Join the absolute path from UNTAR.out.untar to the fastq file names
+    fastqs = fastq_readstructure_pairs.collect{it[2]/it[0]}.join(" ")
+    // Create a list of read structures, Example: 8B 8B 150T
+    read_structures = fastq_readstructure_pairs.collect{it[1]}.join(" ")
+
+    """
+    mkdir output
+    fqtk \\
+        demux \\
+            --inputs ${fastqs} \\
+            --read-structures ${read_structures} \\
+            --output output/ \\
+            --sample-metadata ${sample_sheet} \\
+            ${args}
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        fqtk: \$(echo \$(fqtk --version 2>&1) | cut -d " " -f2)
+    """
+}
+

--- a/modules/nf-core/fqtk/meta.yml
+++ b/modules/nf-core/fqtk/meta.yml
@@ -1,0 +1,54 @@
+name: "fqtk"
+description: Demultiplex fastq files
+keywords:
+  - demultiplex
+  - fastq
+tools:
+  - "fqtk":
+      description: "A toolkit for working with FASTQ files, written in Rust."
+      homepage: "https://github.com/fulcrumgenomics/fqtk"
+      documentation: "https://github.com/fulcrumgenomics/fqtk"
+      tool_dev_url: "None"
+      licence: "['MIT']"
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - sample_sheet:
+      type: file
+      description: Tsv file, with two columns sample_id and barcode
+      pattern: "*.{tsv}"
+  - fastq_readstructure_pairs:
+      type: list
+      description: List of lists i.e. [[<fastq file name>, <read structure>, <absolute path to fastq directory>],...]
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - sample_fastq:
+      type: file
+      description: Demultiplexed per-sample FASTQ files
+      pattern: "output/*R*.fastq.gz"
+  - metrics:
+      type: file
+      description: |
+        Demultiplexing summary stats; sample_id, barcode templates, frac_templates, ratio_to_mean, ratio_to_best
+      pattern: "output/demux-metrics.txt"
+  - most_frequent_unmatched:
+    type: file
+    description: |
+      File containing unmatched fastq records
+    pattern: "output/unmatched*.fq.gz"
+
+authors:
+  - "Samantha White @sam-white04"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -68,7 +68,7 @@
             "properties": {
                 "demultiplexer": {
                     "type": "string",
-                    "enum": ["sgdemux", "bclconvert", "bcl2fastq", "bases2fastq"],
+                    "enum": ["sgdemux", "bclconvert", "bcl2fastq", "bases2fastq", "fqtk"],
                     "description": "Demultiplexer to use.",
                     "fa_icon": "fas fa-microscope"
                 }

--- a/subworkflows/local/fqtk_demultiplex/main.nf
+++ b/subworkflows/local/fqtk_demultiplex/main.nf
@@ -1,0 +1,98 @@
+#!/usr/bin/env nextflow
+
+//
+// Demultiplex FASTQ files with fqtk
+//
+
+include { FQTK }  from "../../../modules/nf-core/fqtk/main"
+include {CSV2TSV} from "../../../modules/local/csv2tsv"
+
+workflow FQTK_DEMULTIPLEX {
+    take:
+        ch_input     // [[id:"", lane:""],samplesheet.csv, [[fastq_name, read_structure, fastq_dir]]]
+
+    main:
+        // Convert csv to tsv
+        CSV2TSV( ch_input )
+        
+        // MODULE: fqtk
+        FQTK( CSV2TSV.out.ch_output )
+
+        // Generate meta for each fastq
+        ch_fastq_with_meta = generate_fastq_meta(FQTK.out.sample_fastq)
+
+    emit:
+        fastq                   = ch_fastq_with_meta
+        metrics                 = FQTK.out.metrics 
+        unassigned              = FQTK.out.most_frequent_unmatched 
+        versions                = FQTK.out.versions
+}
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    FUNCTIONS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+// Add meta values to fastq channel
+def generate_fastq_meta(ch_reads) {
+    // Create a tuple with the meta.id and the fastq
+    ch_reads.transpose().map{
+        fc_meta, fastq ->
+        def meta = [
+            "id": fastq.getSimpleName().toString() - ~/_R[0-9].*$/,
+            "samplename": fastq.getSimpleName().toString() - ~/_R[0-9].*$/,
+            "readgroup": [:],
+            "fcid": fc_meta.id,
+            "lane": fc_meta.lane
+        ]
+        meta.readgroup = readgroup_from_fastq(fastq)
+        meta.readgroup.SM = meta.samplename
+
+        return [ meta , fastq ]
+    }
+    // Group by meta.id for PE samples
+    .groupTuple(by: [0])
+    // Add meta.single_end
+    .map {
+        meta, fastq ->
+        if (fastq.size() == 1){
+            meta.single_end = true
+        } else {
+            meta.single_end = false
+        }
+        return [ meta, fastq.flatten() ]
+    }
+}
+
+// https://github.com/nf-core/sarek/blob/7ba61bde8e4f3b1932118993c766ed33b5da465e/workflows/sarek.nf#L1014-L1040
+def readgroup_from_fastq(path) {
+    // expected format:
+    // xx:yy:FLOWCELLID:LANE:... (seven fields)
+
+    def line
+
+    path.withInputStream {
+        InputStream gzipStream = new java.util.zip.GZIPInputStream(it)
+        Reader decoder = new InputStreamReader(gzipStream, 'ASCII')
+        BufferedReader buffered = new BufferedReader(decoder)
+        line = buffered.readLine()
+    }
+    assert line.startsWith('@')
+    line = line.substring(1)
+    def fields = line.split(':')
+    def rg = [:]
+
+    // "@<instrument>:<run number>:<flowcell ID>:<lane>:<tile>:<x-pos>:<y-pos>:UMI <read>:N:0:<index sequence>"
+    sequencer_serial = fields[0]
+    run_nubmer       = fields[1]
+    fcid             = fields[2]
+    lane             = fields[3]
+    index            = fields[-1] =~ /[GATC+-]/ ? fields[-1] : ""
+
+    rg.ID = [fcid,lane].join(".")
+    rg.PU = [fcid, lane, index].findAll().join(".")
+    rg.PL = "SINGULAR"
+
+    return rg
+}

--- a/subworkflows/local/fqtk_demultiplex/main.nf
+++ b/subworkflows/local/fqtk_demultiplex/main.nf
@@ -5,7 +5,7 @@
 //
 
 include { FQTK }  from "../../../modules/nf-core/fqtk/main"
-include {CSV2TSV} from "../../../modules/local/csv2tsv"
+include { CSV2TSV } from "../../../modules/local/csv2tsv"
 
 workflow FQTK_DEMULTIPLEX {
     take:

--- a/tests/pipeline/default/fqtk.nf.test
+++ b/tests/pipeline/default/fqtk.nf.test
@@ -1,0 +1,76 @@
+nextflow_pipeline {
+
+    name "Test FQTK"
+    script "main.nf"
+
+    test("Should run without failures") {
+
+        when {
+            params {
+                input = "$baseDir/assets/inputs/fqtk-samplesheet.csv"
+                demultiplexer = 'fqtk'
+                outdir = "$outputDir"
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert workflow.trace.succeeded().size() == 105
+
+            assert snapshot(
+                path("$outputDir/test/demux-metrics.txt"),
+            ).match()
+
+            assert new File("$outputDir/test/unmatched_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/unmatched_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s10_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s10_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s11_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s11_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s12_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s12_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s13_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s13_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s14_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s14_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s15_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s15_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s16_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s16_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s17_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s17_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s18_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s18_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s19_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s19_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s1_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s1_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s20_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s20_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s21_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s21_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s22_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s22_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s23_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s23_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s24_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s24_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s2_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s2_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s3_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s3_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s4_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s4_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s5_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s5_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s6_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s6_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s7_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s7_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s8_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s8_2.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s9_1.fastp.fastq.gz").exists()
+            assert new File("$outputDir/test/s9_2.fastp.fastq.gz").exists()
+        }
+    }
+}

--- a/tests/pipeline/default/fqtk.nf.test.snap
+++ b/tests/pipeline/default/fqtk.nf.test.snap
@@ -1,0 +1,8 @@
+{
+    "Should run without failures": {
+        "content": [
+        "demux-metrics.txt:md5,1d587fa959f9129155314cf531103347"
+    ],
+        "timestamp": "2023-01-18T23:52:50+0000"
+    }
+}

--- a/workflows/demultiplex.nf
+++ b/workflows/demultiplex.nf
@@ -5,7 +5,7 @@
 */
 
 def valid_params = [
-    demultiplexers: ["bclconvert","bcl2fastq","bases2fastq","sgdemux"]
+    demultiplexers: ["bclconvert","bcl2fastq","bases2fastq","sgdemux","fqtk"]
 ]
 
 def summary_params = NfcoreSchema.paramsSummaryMap(workflow, params)
@@ -22,7 +22,6 @@ for (param in checkPathParamList) { if (param) { file(param, checkIfExists: true
 
 // Check mandatory parameters
 if (params.input) { ch_input = file(params.input) } else { exit 1, 'Input samplesheet not specified!' }
-
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     CONFIG FILES
@@ -43,8 +42,9 @@ ch_multiqc_custom_methods_description = params.multiqc_methods_description ? fil
 //
 // SUBWORKFLOW: Consisting of a mix of local and nf-core/modules
 //
-include { BCL_DEMULTIPLEX   } from '../subworkflows/nf-core/bcl_demultiplex/main'
-include { BASES_DEMULTIPLEX } from '../subworkflows/local/bases_demultiplex/main'
+include { BCL_DEMULTIPLEX      } from '../subworkflows/nf-core/bcl_demultiplex/main'
+include { BASES_DEMULTIPLEX    } from '../subworkflows/local/bases_demultiplex/main'
+include { FQTK_DEMULTIPLEX     } from '../subworkflows/local/fqtk_demultiplex/main'
 include { SINGULAR_DEMULTIPLEX } from '../subworkflows/local/singular_demultiplex/main'
 
 /*
@@ -73,35 +73,54 @@ include { MD5SUM                        } from '../modules/nf-core/md5sum/main'
 def multiqc_report = []
 
 workflow DEMULTIPLEX {
-
     // Value inputs
-    demultiplexer = params.demultiplexer                                   // string: bclconvert, bcl2fastq, bases2fastq, sgdemux
+    demultiplexer = params.demultiplexer                                   // string: bclconvert, bcl2fastq, bases2fastq, sgdemux, fqtk
     trim_fastq    = params.trim_fastq                                      // boolean: true, false
     skip_tools    = params.skip_tools ? params.skip_tools.split(',') : []  // list: [falco, fastp, multiqc]
 
     // Channel inputs
-
-
     ch_versions = Channel.empty()
     ch_multiqc_files = Channel.empty()
 
     // Sanitize inputs and separate input types
-    ch_inputs = extract_csv(ch_input)
-    ch_inputs.dump(tag: 'DEMULTIPLEX::inputs',{FormattingService.prettyFormat(it)})
+    // FQTK's input contains an extra column 'per_flowcell_manifest' so it is handled seperately
+    // For reference - assets/inputs/fqtk-samplesheet.csv vs assets/inputs/sgdemux-samplesheet
+    if (demultiplexer == 'fqtk'){
+        ch_inputs = extract_csv_fqtk(ch_input)
 
-    // Split flowcells into separate channels containg run as tar and run as path
-    // https://nextflow.slack.com/archives/C02T98A23U7/p1650963988498929
-    ch_flowcells = ch_inputs
-        .branch { meta, samplesheet, run ->
-            tar: run.toString().endsWith('.tar.gz')
-            dir: true
-        }
+        ch_inputs.dump(tag: 'DEMULTIPLEX::inputs',{FormattingService.prettyFormat(it)})
 
-    ch_flowcells_tar = ch_flowcells.tar
-        .multiMap { meta, samplesheet, run ->
-            samplesheets: [ meta, samplesheet ]
-            run_dirs: [ meta, run ]
-        }
+        // Split flowcells into separate channels containg run as tar and run as path
+        // https://nextflow.slack.com/archives/C02T98A23U7/p1650963988498929
+        ch_flowcells = ch_inputs
+            .branch { meta, samplesheet, run, manifest ->
+                tar: run.toString().endsWith('.tar.gz')
+                dir: true
+            }
+
+        ch_flowcells_tar = ch_flowcells.tar
+            .multiMap { meta, samplesheet, run, manifest ->
+                samplesheets: [ meta, samplesheet, manifest ]
+                run_dirs: [ meta, run ]
+            }
+    } else {
+        ch_inputs = extract_csv(ch_input)
+        ch_inputs.dump(tag: 'DEMULTIPLEX::inputs',{FormattingService.prettyFormat(it)})
+
+        // Split flowcells into separate channels containg run as tar and run as path
+        // https://nextflow.slack.com/archives/C02T98A23U7/p1650963988498929
+        ch_flowcells = ch_inputs
+            .branch { meta, samplesheet, run ->
+                tar: run.toString().endsWith('.tar.gz')
+                dir: true
+            }
+
+        ch_flowcells_tar = ch_flowcells.tar
+            .multiMap { meta, samplesheet, run ->
+                samplesheets: [ meta, samplesheet ]
+                run_dirs: [ meta, run ]
+            } 
+    }
 
     // MODULE: untar
     // Runs when run_dir is a tar archive
@@ -112,7 +131,6 @@ workflow DEMULTIPLEX {
     // Merge the two channels back together
     ch_flowcells = ch_flowcells.dir.mix(ch_flowcells_tar_merged)
 
-    //
     // RUN demultiplexing
     //
     ch_raw_fastq = Channel.empty()
@@ -143,6 +161,28 @@ workflow DEMULTIPLEX {
             ch_raw_fastq = ch_raw_fastq.mix(SINGULAR_DEMULTIPLEX.out.fastq)
             ch_multiqc_files = ch_multiqc_files.mix(SINGULAR_DEMULTIPLEX.out.metrics.map { meta, metrics -> return metrics} )
             ch_versions = ch_versions.mix(SINGULAR_DEMULTIPLEX.out.versions)
+            break
+        case 'fqtk':
+            // MODULE: sgdemux
+            // Runs when "demultiplexer" is set to "fqtk"
+
+            // Collect fastqs and read structures from field 2 of ch_flowcells
+            fastq_read_structure = ch_flowcells.map{it[2]}
+                .splitCsv(header:true)
+                .map{[it.fastq, it.read_structure]}
+            
+            // Combine the directory containing the fastq with the fastq name and read structure
+            // [example_R1.fastq.gz, 150T, ./work/98/30bc..78y/fastqs/]
+            fastqs_with_paths = fastq_read_structure.combine(UNTAR.out.untar.collect{it[1]}).toList()
+            
+            // Format ch_input like so:
+            // [[meta:id], <path to sample names and barcodes in tsv: path>, [<fastq name: string>, <read structure: string>, <path to fastqs: path>]]]
+            ch_input = ch_flowcells.merge( fastqs_with_paths ) { a,b -> tuple(a[0], a[1], b)}
+
+            FQTK_DEMULTIPLEX ( ch_input )
+            ch_raw_fastq = ch_raw_fastq.mix(FQTK_DEMULTIPLEX.out.fastq)
+            ch_multiqc_files = ch_multiqc_files.mix(FQTK_DEMULTIPLEX.out.metrics.map { meta, metrics -> return metrics} )
+            ch_versions = ch_versions.mix(FQTK_DEMULTIPLEX.out.versions)
             break
         default:
             exit 1, "Unknown demultiplexer: ${demultiplexer}"
@@ -223,37 +263,37 @@ workflow.onComplete {
     FUNCTIONS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
-
 // Extract information (meta data + file(s)) from csv file(s)
-def extract_csv(input_csv) {
+def extract_csv(input_csv, input_schema=null) {
 
     // Flowcell Sheet schema
     // Possible values for the "content" column: [meta, path, number, string, bool]
-    def input_schema = [
-        'columns': [
-            'id': [
-                'content': 'meta',
-                'meta_name': 'id',
-                'pattern': '',
+    if(input_schema == null){
+        def default_input_schema = [
+            'columns': [
+                'id': [
+                    'content': 'meta',
+                    'meta_name': 'id',
+                    'pattern': '',
+                ],
+                'samplesheet': [
+                    'content': 'path',
+                    'pattern': '^.*.csv$',
+                ],
+                'lane': [
+                    'content': 'meta',
+                    'meta_name': 'lane',
+                    'pattern': '',
+                ],
+                'flowcell': [
+                    'content': 'path',
+                    'pattern': '',
+                ],
             ],
-            'samplesheet': [
-                'content': 'path',
-                'pattern': '^.*.csv$',
-            ],
-            'lane': [
-                'content': 'meta',
-                'meta_name': 'lane',
-                'pattern': '',
-            ],
-            'flowcell': [
-                'content': 'path',
-                'pattern': '',
-            ],
-
-        ],
-        required: ['id','flowcell', 'samplesheet'],
-    ]
-
+            required: ['id','flowcell', 'samplesheet'],
+        ]
+        input_schema = default_input_schema
+    }
     // Don't change these variables
     def row_count = 1
     def all_columns = input_schema.columns.keySet().collect()
@@ -338,6 +378,48 @@ def parse_flowcell_csv(row) {
     def flowcell        = file(row.flowcell, checkIfExists: true)
     def samplesheet     = file(row.samplesheet, checkIfExists: true)
     return [meta, samplesheet, flowcell]
+}
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    FUNCTIONS FOR FQTK
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+// Extract information (meta data + file(s)) from csv file(s)
+def extract_csv_fqtk(input_csv) {
+
+    // Flowcell Sheet schema
+    // Possible values for the "content" column: [meta, path, number, string, bool]
+    def input_schema = [
+        'columns': [
+            'id': [
+                'content': 'meta',
+                'meta_name': 'id',
+                'pattern': '',
+            ],
+            'samplesheet': [
+                'content': 'path',
+                'pattern': '^.*.csv$',
+            ],
+            'lane': [
+                'content': 'meta',
+                'meta_name': 'lane',
+                'pattern': '',
+            ],
+            'flowcell': [
+                'content': 'path',
+                'pattern': '',
+            ],
+            'per_flowcell_manifest': [
+                'content': 'path',
+                'pattern': '',
+            ]
+        ],
+        required: ['id','flowcell', 'samplesheet', 'per_flowcell_manifest'],
+    ]
+
+    return extract_csv(input_csv, input_schema)
 }
 
 /*


### PR DESCRIPTION
Hello, 

I have added [fqtk](https://github.com/fulcrumgenomics/fqtk) as an optional demultiplexer. The tool fqtk requires an additional input to be provided as a path in the 5th column of `--input samplesheet.csv`.  

Thank you, 
Samantha White
<!--
# nf-core/demultiplex pull request

Many thanks for contributing to nf-core/demultiplex!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/demultiplex/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/demultiplex/tree/master/.github/CONTRIBUTING.md)- [x] If necessary, also make a PR on the nf-core/demultiplex _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated. (@sam-white04 Will update as soon as PR is posted)
- [x] `README.md` is updated (including new tool citations and authors/contributors).
