### PR TITLE
Fix MultiQC report generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#127](https://github.com/nf-core/demultiplex/pull/127) Add `singularity.registry = 'quay.io'` and bump NF version to 23.04.0
 - [#140](https://github.com/nf-core/demultiplex/pull/140) Make it possible to skip MultiQC, fix error raising
+- [#145](https://github.com/nf-core/demultiplex/pull/145) Fix MultiQC report generation
 
 ## `Removed`
 

--- a/tests/pipeline/bclconvert.nf.test
+++ b/tests/pipeline/bclconvert.nf.test
@@ -20,10 +20,10 @@ nextflow_pipeline {
                 { assert workflow.success },
                 { assert snapshot(UTILS.removeNextflowVersion("$outputDir")).match("software_versions") },
                 { assert workflow.trace.succeeded().size() == 6 },
-                // FIXME https://github.com/nf-core/demultiplex/issues/64
-                // { assert snapshot(path("$outputDir/multiqc/multiqc_data/multiqc_bclconvert_bylane.txt"),
-                //                 path("$outputDir/multiqc/multiqc_data/multiqc_fastp.txt"),
-                //                 path("$outputDir/multiqc/multiqc_data/multiqc_bclconvert_bysample.txt")).match("multiqc") },
+                { assert snapshot(path("$outputDir/multiqc/multiqc_data/multiqc_bclconvert_bylane.txt"),
+                        path("$outputDir/multiqc/multiqc_data/multiqc_fastp.txt"),
+                        path("$outputDir/multiqc/multiqc_data/multiqc_bclconvert_bysample.txt")
+                    ).match("multiqc") },
                 { assert snapshot(path("$outputDir/220422_M11111_0222_000000000-K9H97/Sample1_S1_L001.fastp.fastq.gz"),
                         path("$outputDir/220422_M11111_0222_000000000-K9H97/Sample1_S1_L001_R1_001.fastq.gz"),
                         path("$outputDir/220422_M11111_0222_000000000-K9H97/Sample1_S1_L001_summary.txt"),

--- a/workflows/demultiplex.nf
+++ b/workflows/demultiplex.nf
@@ -228,7 +228,6 @@ workflow DEMULTIPLEX {
         methods_description    = WorkflowDemultiplex.methodsDescriptionText(workflow, ch_multiqc_custom_methods_description, params)
         ch_methods_description = Channel.value(methods_description)
     
-        ch_multiqc_files = Channel.empty()
         ch_multiqc_files = ch_multiqc_files.mix(ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
         ch_multiqc_files = ch_multiqc_files.mix(ch_methods_description.collectFile(name: 'methods_description_mqc.yaml'))
         ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())


### PR DESCRIPTION
A bug was introduced in #132: the MultiQC file channel was flushed empty before the report was constructed. This led to empty reports. This PR fixes this issue.

Fixes #64, fixes #144

NB: linting tests fail but I suspect it's because of the v2.10 template update, should be fixed once #141 is reviewed and merged.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [X] Make sure your code lints (`nf-core lint`).
- [X] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [X] `CHANGELOG.md` is updated.
