### PR TITLE
Add Kraken2 step

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -146,6 +146,14 @@ process {
         ]
     }
 
+    withName: KRAKEN2 {
+        publishDir = [
+            path: { "${params.outdir}/${meta.fcid}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null: filename }
+        ]
+    }
+
     withName: MD5SUM {
         publishDir = [
             path: { "${params.outdir}/${meta.fcid}" },

--- a/modules.json
+++ b/modules.json
@@ -40,6 +40,11 @@
                         "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
                         "installed_by": ["modules"]
                     },
+                    "kraken2/kraken2": {
+                        "branch": "master",
+                        "git_sha": "603ecbd9f45300c9788f197d2a15a005685b4220",
+                        "installed_by": ["fastq_contam_seqtk_kraken"]
+                    },
                     "md5sum": {
                         "branch": "master",
                         "git_sha": "5c460c5a4736974abde2843294f35307ee2b0e5e",
@@ -49,6 +54,11 @@
                         "branch": "master",
                         "git_sha": "a6e11ac655e744f7ebc724be669dd568ffdc0e80",
                         "installed_by": ["modules"]
+                    },
+                    "seqtk/sample": {
+                        "branch": "master",
+                        "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
+                        "installed_by": ["fastq_contam_seqtk_kraken"]
                     },
                     "sgdemux": {
                         "branch": "master",
@@ -65,6 +75,11 @@
             "subworkflows": {
                 "nf-core": {
                     "bcl_demultiplex": {
+                        "branch": "master",
+                        "git_sha": "dedc0e31087f3306101c38835d051bf49789445a",
+                        "installed_by": ["subworkflows"]
+                    },
+                    "fastq_contam_seqtk_kraken": {
                         "branch": "master",
                         "git_sha": "dedc0e31087f3306101c38835d051bf49789445a",
                         "installed_by": ["subworkflows"]

--- a/modules/nf-core/kraken2/kraken2/main.nf
+++ b/modules/nf-core/kraken2/kraken2/main.nf
@@ -1,0 +1,58 @@
+process KRAKEN2_KRAKEN2 {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "bioconda::kraken2=2.1.2 conda-forge::pigz=2.6"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/mulled-v2-5799ab18b5fc681e75923b2450abaa969907ec98:87fc08d11968d081f3e8a37131c1f1f6715b6542-0' :
+        'biocontainers/mulled-v2-5799ab18b5fc681e75923b2450abaa969907ec98:87fc08d11968d081f3e8a37131c1f1f6715b6542-0' }"
+
+    input:
+    tuple val(meta), path(reads)
+    path  db
+    val save_output_fastqs
+    val save_reads_assignment
+
+    output:
+    tuple val(meta), path('*.classified{.,_}*')     , optional:true, emit: classified_reads_fastq
+    tuple val(meta), path('*.unclassified{.,_}*')   , optional:true, emit: unclassified_reads_fastq
+    tuple val(meta), path('*classifiedreads.txt')   , optional:true, emit: classified_reads_assignment
+    tuple val(meta), path('*report.txt')                           , emit: report
+    path "versions.yml"                                            , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def paired       = meta.single_end ? "" : "--paired"
+    def classified   = meta.single_end ? "${prefix}.classified.fastq"   : "${prefix}.classified#.fastq"
+    def unclassified = meta.single_end ? "${prefix}.unclassified.fastq" : "${prefix}.unclassified#.fastq"
+    def classified_option = save_output_fastqs ? "--classified-out ${classified}" : ""
+    def unclassified_option = save_output_fastqs ? "--unclassified-out ${unclassified}" : ""
+    def readclassification_option = save_reads_assignment ? "--output ${prefix}.kraken2.classifiedreads.txt" : "--output /dev/null"
+    def compress_reads_command = save_output_fastqs ? "pigz -p $task.cpus *.fastq" : ""
+
+    """
+    kraken2 \\
+        --db $db \\
+        --threads $task.cpus \\
+        --report ${prefix}.kraken2.report.txt \\
+        --gzip-compressed \\
+        $unclassified_option \\
+        $classified_option \\
+        $readclassification_option \\
+        $paired \\
+        $args \\
+        $reads
+
+    $compress_reads_command
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        kraken2: \$(echo \$(kraken2 --version 2>&1) | sed 's/^.*Kraken version //; s/ .*\$//')
+        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/kraken2/kraken2/meta.yml
+++ b/modules/nf-core/kraken2/kraken2/meta.yml
@@ -1,0 +1,75 @@
+name: kraken2_kraken2
+description: Classifies metagenomic sequence data
+keywords:
+  - classify
+  - metagenomics
+  - fastq
+  - db
+tools:
+  - kraken2:
+      description: |
+        Kraken2 is a taxonomic sequence classifier that assigns taxonomic labels to sequence reads
+      homepage: https://ccb.jhu.edu/software/kraken2/
+      documentation: https://github.com/DerrickWood/kraken2/wiki/Manual
+      doi: 10.1186/s13059-019-1891-0
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: |
+        List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+        respectively.
+  - db:
+      type: directory
+      description: Kraken2 database
+  - save_output_fastqs:
+      type: string
+      description: |
+        If true, optional commands are added to save classified and unclassified reads
+        as fastq files
+  - save_reads_assignment:
+      type: string
+      description: |
+        If true, an optional command is added to save a file reporting the taxonomic
+        classification of each input read
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - classified_reads_fastq:
+      type: file
+      description: |
+        Reads classified as belonging to any of the taxa
+        on the Kraken2 database.
+      pattern: "*{fastq.gz}"
+  - unclassified_reads_fastq:
+      type: file
+      description: |
+        Reads not classified to any of the taxa
+        on the Kraken2 database.
+      pattern: "*{fastq.gz}"
+  - classified_reads_assignment:
+      type: file
+      description: |
+        Kraken2 output file indicating the taxonomic assignment of
+        each input read
+  - report:
+      type: file
+      description: |
+        Kraken2 report containing stats about classified
+        and not classifed reads.
+      pattern: "*.{report.txt}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@joseespinosa"
+  - "@drpatelh"

--- a/modules/nf-core/seqtk/sample/main.nf
+++ b/modules/nf-core/seqtk/sample/main.nf
@@ -1,0 +1,45 @@
+process SEQTK_SAMPLE {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "bioconda::seqtk=1.3"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/seqtk:1.3--h5bf99c6_3' :
+        'biocontainers/seqtk:1.3--h5bf99c6_3' }"
+
+    input:
+    tuple val(meta), path(reads), val(sample_size)
+
+    output:
+    tuple val(meta), path("*.fastq.gz"), emit: reads
+    path "versions.yml"                , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args   = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    if (!(args ==~ /.*-s[0-9]+.*/)) {
+        args += " -s100"
+    }
+    if ( !sample_size ) {
+        error "SEQTK/SAMPLE must have a sample_size value included"
+    }
+    """
+    printf "%s\\n" $reads | while read f;
+    do
+        seqtk \\
+            sample \\
+            $args \\
+            \$f \\
+            $sample_size \\
+            | gzip --no-name > ${prefix}_\$(basename \$f)
+    done
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        seqtk: \$(echo \$(seqtk 2>&1) | sed 's/^.*Version: //; s/ .*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/seqtk/sample/meta.yml
+++ b/modules/nf-core/seqtk/sample/meta.yml
@@ -1,0 +1,45 @@
+name: seqtk_sample
+description: Subsample reads from FASTQ files
+keywords:
+  - sample
+tools:
+  - seqtk:
+      description: Seqtk is a fast and lightweight tool for processing sequences in the FASTA or FASTQ format. Seqtk sample command subsamples sequences.
+      homepage: https://github.com/lh3/seqtk
+      documentation: https://docs.csc.fi/apps/seqtk/
+      tool_dev_url: https://github.com/lh3/seqtk
+      licence: ["MIT"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: List of input FastQ files
+      pattern: "*.{fastq.gz}"
+  - sample_size:
+      type: value
+      description: Number of reads to sample.
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - reads:
+      type: file
+      description: Subsampled FastQ files
+      pattern: "*.{fastq.gz}"
+
+authors:
+  - "@kaurravneet4123"
+  - "@sidorov-si"
+  - "@adamrtalbot"

--- a/nextflow.config
+++ b/nextflow.config
@@ -19,6 +19,12 @@ params {
     // Options: tooling
     skip_tools                  = []            // list [fastp, fastqc]
 
+    // seqtk sample options
+    sample_size                 = 10000
+
+    // Kraken2 options
+    kraken_db                   = null
+
     // MultiQC options
     multiqc_config             = null
     multiqc_title              = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -20,6 +20,17 @@
                     "type": "string",
                     "default": null,
                     "description": "Comma-separated list of tools to skip (fastp,falco,multiqc)"
+                },
+                "sample_size": {
+                    "type": "integer",
+                    "default": 10000,
+                    "description": "Number of reads to subsample for contamination detection."
+                },
+                "kraken_db": {
+                    "type": "string",
+                    "format": "directory-path",
+                    "default": null,
+                    "description": "path to Kraken2 DB to use for screening"
                 }
             }
         },

--- a/subworkflows/nf-core/fastq_contam_seqtk_kraken/main.nf
+++ b/subworkflows/nf-core/fastq_contam_seqtk_kraken/main.nf
@@ -1,0 +1,46 @@
+#!/usr/bin/env nextflow
+
+//
+// FASTQ_CONTAM_SEQTK_KRAKEN: Subsample FASTQs and perform contamination screening
+//
+include { KRAKEN2_KRAKEN2 as KRAKEN2 } from '../../../modules/nf-core/kraken2/kraken2/main'
+include { SEQTK_SAMPLE               } from '../../../modules/nf-core/seqtk/sample/main'
+
+workflow FASTQ_CONTAM_SEQTK_KRAKEN {
+
+    take:
+        ch_reads    //channel: [mandatory] meta,reads
+        sample_size //string:  [mandatory] number of reads to subsample
+        kraken2_db  //string:  [mandatory] path to Kraken2 DB to use for screening
+
+    main:
+        ch_reports  = Channel.empty()
+        ch_versions = Channel.empty()
+
+        // Combine all combinations of reads with sample_size(s).
+        // Note using more than 1 sample_size can cause file collisions
+        // We add n_reads to meta to avoid collisions
+        ch_reads
+            .combine(sample_size)
+            .map{ it ->
+                def meta2 = it[0] + [n_reads: it[2]]
+                [ meta2, it[1], it[2] ]
+            }
+            .set { ch_reads_with_n }
+
+        SEQTK_SAMPLE(ch_reads_with_n)
+
+        ch_versions.mix(SEQTK_SAMPLE.out.versions)
+
+        KRAKEN2(SEQTK_SAMPLE.out.reads,
+                kraken2_db,
+                false,
+                false
+        )
+        ch_versions = ch_versions.mix(KRAKEN2.out.versions.first())
+        ch_reports  = ch_reports.mix(KRAKEN2.out.report)
+
+    emit:
+        reports  = ch_reports     // channel: [ [meta], log  ]
+        versions = ch_versions    // channel: [ versions.yml ]
+}

--- a/subworkflows/nf-core/fastq_contam_seqtk_kraken/meta.yml
+++ b/subworkflows/nf-core/fastq_contam_seqtk_kraken/meta.yml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "FASTQ_CONTAM_SEQTK_KRAKEN"
+description: Produces a contamination report from FastQ input after subsampling
+keywords:
+  - statistics
+  - fastq
+  - contamination
+components:
+  - kraken2/kraken2
+  - seqtk/sample
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: List of input FastQ files of size 1 and 2 for single-end and paired-end data, respectively
+  - sample_size:
+      type: string
+      description: Number of reads to subsample for contamination detection.
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - report:
+      type: file
+      description: Kraken2 contamination report
+      pattern: "*.txt"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@apeltzer"

--- a/tests/pipeline/kraken.nf.test
+++ b/tests/pipeline/kraken.nf.test
@@ -1,0 +1,39 @@
+nextflow_workflow {
+
+    name "Test Workflow "
+    script "workflows/demultiplex.nf"
+    workflow "DEMULTIPLEX"
+    tag "kraken"
+    tag "pipeline"
+
+    test("KRAKEN") {
+
+        setup {
+            run("UNTAR") {
+                script "modules/nf-core/untar/main.nf"
+                process {
+                    """
+                    input[0] = Channel.of([ [], file("https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/sarscov2/genome/db/kraken2.tar.gz", checkIfExists: true) ])
+                    """
+                }
+            }
+        }
+
+        when {
+            params {
+                input         = 'https://raw.githubusercontent.com/nf-core/test-datasets/demultiplex/samplesheet/1.3.0/flowcell_input.csv'
+                demultiplexer = 'bclconvert'
+                outdir        = "$outputDir"
+                //kraken_db     = UNTAR.out.untar.map{ it[1] }
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+            )
+        }
+
+    }
+
+}

--- a/workflows/demultiplex.nf
+++ b/workflows/demultiplex.nf
@@ -33,10 +33,11 @@ ch_multiqc_custom_methods_description = params.multiqc_methods_description ? fil
 //
 // SUBWORKFLOW: Consisting of a mix of local and nf-core/modules
 //
-include { BCL_DEMULTIPLEX      } from '../subworkflows/nf-core/bcl_demultiplex/main'
-include { BASES_DEMULTIPLEX    } from '../subworkflows/local/bases_demultiplex/main'
-include { FQTK_DEMULTIPLEX     } from '../subworkflows/local/fqtk_demultiplex/main'
-include { SINGULAR_DEMULTIPLEX } from '../subworkflows/local/singular_demultiplex/main'
+include { BCL_DEMULTIPLEX           } from '../subworkflows/nf-core/bcl_demultiplex/main'
+include { FASTQ_CONTAM_SEQTK_KRAKEN } from '../subworkflows/nf-core/fastq_contam_seqtk_kraken/main'
+include { BASES_DEMULTIPLEX         } from '../subworkflows/local/bases_demultiplex/main'
+include { FQTK_DEMULTIPLEX          } from '../subworkflows/local/fqtk_demultiplex/main'
+include { SINGULAR_DEMULTIPLEX      } from '../subworkflows/local/singular_demultiplex/main'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -68,6 +69,9 @@ workflow DEMULTIPLEX {
     demultiplexer = params.demultiplexer                                   // string: bases2fastq, bcl2fastq, bclconvert, fqtk, sgdemux
     trim_fastq    = params.trim_fastq                                      // boolean: true, false
     skip_tools    = params.skip_tools ? params.skip_tools.split(',') : []  // list: [falco, fastp, multiqc]
+    sample_size   = params.sample_size                                     // int
+    kraken_db     = params.kraken_db                                       // path
+
 
     // Channel inputs
     ch_input = file(params.input)
@@ -214,6 +218,17 @@ workflow DEMULTIPLEX {
     // MODULE: md5sum
     // Split file list into separate channels entries and generate a checksum for each
     MD5SUM(ch_fastq_to_qc.transpose())
+
+    // SUBWORKFLOW: FASTQ_CONTAM_SEQTK_KRAKEN
+    if (kraken_db){
+        FASTQ_CONTAM_SEQTK_KRAKEN(
+            ch_fastq_to_qc,
+            [sample_size],
+            kraken_db
+        )
+        ch_versions = ch_versions.mix(FASTQ_CONTAM_SEQTK_KRAKEN.out.versions)
+        ch_multiqc_files = ch_multiqc_files.mix( FASTQ_CONTAM_SEQTK_KRAKEN.out.reports.map { meta, log -> return log })
+    }
 
     // DUMP SOFTWARE VERSIONS
     CUSTOM_DUMPSOFTWAREVERSIONS (


### PR DESCRIPTION
Hi!

I've been working on solving #36 but got stuck when trying to write a test for it, so I thought I could draft this PR and maybe get some feedback on how to move forward from here.

Here are some points worth discussing:
1. Regarding the user interface:
    * It is expected the kraken database is already set up somewhere. For some use cases it will be a major limitation, but I know for a lot of us the database is already set up somewhere. For instance in my case it's readily available on Uppmax. See similar discussion for FastQ Screen (https://github.com/nf-core/modules/issues/3157#issuecomment-1515081330)
    * I wanted to avoid the risk of having conflicting parameters, so the Kraken step is only run when a path to the database is provided. Is this fine, or is there a better way to do this?
1. At the moment, the tests get a small kraken database from the `module` branch on https://github.com/nf-core/test-datasets. Should this database be incorporated into the `demultiplex` branch?
1. I kind of got stuck when writing tests for this. I need a pre-step to untar the database, but I've been unable to feed it to the demultiplex pipeline: as far as I can see, the `params` block cannot execute code and the tests refuse to run as soon as I add a `process` block. Any clue on how I could solve this?

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/demultiplex/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/demultiplex _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
