### PR TITLE
Use teams in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,7 @@
 # Maintainers
-* @matthdsm @emiller88
+* @nf-core/demultiplex
+*.nf.test* @nf-core/nf-test
+.github/workflows/ @nf-core/a-team
 
 # Element
 modules/nf-core/bases2fastq/ @blajoie

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unpublished Version / DEV]
 
+### `Added`
+
+- [#148](https://github.com/nf-core/demultiplex/pull/148) Update CODEOWNERS to use GitHub teams
+
 ### `Changed`
 
 - [#141](https://github.com/nf-core/demultiplex/pull/141) Updated template to nf-core/tools v2.10


### PR DESCRIPTION
Uses the built-in GitHub teams to manage codeowners https://github.com/orgs/nf-core/teams/demultiplex/members