### PR TITLE
Set publish mode for FastQs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "dev" && "${{ matrix.NXF_VER }}" != "latest-everything" ]]; then
             echo matrix='["latest-everything"]' | tee -a $GITHUB_OUTPUT
           else
-            echo matrix='["latest-everything", "22.10.1"]' | tee -a $GITHUB_OUTPUT
+            echo matrix='["latest-everything", "23.04.0"]' | tee -a $GITHUB_OUTPUT
           fi
 
   test:

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -47,6 +47,7 @@ process {
             ],
             [
                 path: { "${params.outdir}/${meta.id}" },
+                mode: params.publish_dir_mode,
                 pattern: "**.fastq.gz",
             ]
         ]
@@ -73,6 +74,7 @@ process {
             ],
             [
                 path: { "${params.outdir}/${meta.id}" },
+                mode: params.publish_dir_mode,
                 pattern: "**.fastq.gz",
             ]
         ]


### PR DESCRIPTION
I think this was set to avoid duplicate copying of the raw fastqs, and assuming most people would run them through fastp.

I'm not opposed to changing this to only publish if `--skip_tools "falco,fastp"` is set or a param like `publish_fastq` is opted in to.

Closes #154 
