### PR TITLE
skip over empty fastqs after demultiplex and continue gracefully

### DIFF
--- a/subworkflows/nf-core/bcl_demultiplex/main.nf
+++ b/subworkflows/nf-core/bcl_demultiplex/main.nf
@@ -7,19 +7,23 @@
 include { BCLCONVERT } from "../../../modules/nf-core/bclconvert/main"
 include { BCL2FASTQ  } from "../../../modules/nf-core/bcl2fastq/main"
 
+// Define the log file path before the workflow starts
+def logFile = new File("${params.outdir}/invalid_fastqs.log")
+
 workflow BCL_DEMULTIPLEX {
     take:
         ch_flowcell     // [[id:"", lane:""],samplesheet.csv, path/to/bcl/files]
         demultiplexer   // bclconvert or bcl2fastq
 
     main:
-        ch_versions = Channel.empty()
-        ch_fastq    = Channel.empty()
-        ch_reports  = Channel.empty()
-        ch_stats    = Channel.empty()
-        ch_interop  = Channel.empty()
+        // Channels
+        ch_versions      = Channel.empty()
+        ch_fastq         = Channel.empty()
+        ch_reports       = Channel.empty()
+        ch_stats         = Channel.empty()
+        ch_interop       = Channel.empty()
 
-        // Split flowcells into separate channels containg run as tar and run as path
+        // Split flowcells into separate channels containing run as tar and run as path
         // https://nextflow.slack.com/archives/C02T98A23U7/p1650963988498929
         ch_flowcell
             .branch { meta, samplesheet, run ->
@@ -35,7 +39,9 @@ workflow BCL_DEMULTIPLEX {
 
         // Runs when run_dir is a tar archive
         // Re-join the metadata and the untarred run directory with the samplesheet
-        ch_flowcells_tar_merged = ch_flowcells_tar.samplesheets.join( ch_flowcells_tar.run_dirs )
+        ch_flowcells_tar_merged = ch_flowcells_tar
+                                    .samplesheets
+                                    .join( ch_flowcells_tar.run_dirs )
 
         // Merge the two channels back together
         ch_flowcells = ch_flowcells.dir.mix(ch_flowcells_tar_merged)
@@ -62,7 +68,7 @@ workflow BCL_DEMULTIPLEX {
         }
 
         // Generate meta for each fastq
-        ch_fastq_with_meta = generate_fastq_meta(ch_fastq)
+        ch_fastq_with_meta = generate_fastq_meta(ch_fastq, logFile)
 
     emit:
         fastq    = ch_fastq_with_meta
@@ -78,34 +84,58 @@ workflow BCL_DEMULTIPLEX {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-// Add meta values to fastq channel
-def generate_fastq_meta(ch_reads) {
-    // Create a tuple with the meta.id and the fastq
-    ch_reads.transpose().map{
-        fc_meta, fastq ->
-        def meta = [
-            "id": fastq.getSimpleName().toString() - ~/_R[0-9]_001.*$/,
-            "samplename": fastq.getSimpleName().toString() - ~/_S[0-9]+.*$/,
-            "readgroup": [:],
-            "fcid": fc_meta.id,
-            "lane": fc_meta.lane
-        ]
-        meta.readgroup = readgroup_from_fastq(fastq)
-        meta.readgroup.SM = meta.samplename
-
-        return [ meta , fastq ]
+// This function appends a given text to a specified log file.
+// If the log file does not exist, it creates a new one.
+def appendToLogFile(String text, File logFile) {
+    if (!logFile.exists()) {
+        logFile.createNewFile()
     }
+    // Convert the text to String if it's a GString
+    String textToWrite = text.toString()
+    logFile << textToWrite + "\n" // Appends the text to the file with a new line
+}
+
+// Add meta values to fastq channel and skip invalid FASTQ files
+def generate_fastq_meta(ch_reads, logFile) {
+    // Create a tuple with the meta.id and the fastq
+    ch_reads.transpose().map { fc_meta, fastq ->
+        // Check if the FASTQ file is empty or has invalid content
+        def isValid = fastq.withInputStream { is ->
+            new java.util.zip.GZIPInputStream(is).withReader('ASCII') { reader ->
+                def line = reader.readLine()
+                line != null && line.startsWith('@')
+            }
+        }
+
+        def meta = null
+        if (isValid) {
+            meta = [
+                "id": fastq.getSimpleName().toString() - ~/_R[0-9]_001.*$/,
+                "samplename": fastq.getSimpleName().toString() - ~/_S[0-9]+.*$/,
+                "readgroup": [:],
+                "fcid": fc_meta.id,
+                "lane": fc_meta.lane
+            ]
+            meta.readgroup = readgroup_from_fastq(fastq)
+            meta.readgroup.SM = meta.samplename
+        } else {
+            appendToLogFile(
+                "Empty or invalid FASTQ file: ${fastq}",
+                logFile
+                )
+                fastq = null
+                }
+
+        return [meta, fastq]
+    }.filter { it[0] != null }
     // Group by meta.id for PE samples
     .groupTuple(by: [0])
     // Add meta.single_end
-    .map {
-        meta, fastq ->
-        if (fastq.size() == 1){
-            meta.single_end = true
-        } else {
-            meta.single_end = false
-        }
-        return [ meta, fastq.flatten() ]
+    .map { meta, fastq ->
+        if (meta != null) {
+                meta.single_end = fastq.size() == 1
+                }
+        return [meta, fastq.flatten()]
     }
 }
 


### PR DESCRIPTION
<!--
# nf-core/demultiplex pull request

Many thanks for contributing to nf-core/demultiplex!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/demultiplex/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/demultiplex/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/demultiplex _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

---
### Title of PR:
"Enhanced Resilience to Empty or Invalid FASTQ Files with Logging Functionality"

### Description:

**Changes Made**:

1. **Introduction of a Log File**:
   - Implemented a global log file (`${params.outdir}/invalid_fastqs.log`) for tracking empty or invalid FASTQ files, enhancing post-run analysis.

2. **Modified `generate_fastq_meta` Function**:
   - Updated `generate_fastq_meta` to gracefully handle empty or invalid FASTQ files, preventing pipeline interruption.
   - Added `logFile` as a new parameter for logging these occurrences.

3. **New Function - `appendToLogFile`**:
   - Introduced `appendToLogFile`, a utility function for appending messages to the log file. This function improves maintainability and includes a check to handle Groovy GStrings.

### Reason for Changes:
- **Improving Pipeline Robustness**: Aims to bolster the pipeline's resilience against edge cases like empty or invalid FASTQ files.
- **Enhanced Debugging and Transparency**: Offers a clear record of skipped files, aiding in debugging and ensuring data quality.
- **Maintainability and Code Organization**: The addition of `appendToLogFile` and the parameterization of `logFile` align with best coding practices, enhancing code reusability and organization.

### Impact:
- These enhancements bolster the pipeline's robustness without altering its core functionality, ensuring a smooth experience when encountering empty or invalid FASTQ files.

### Use Cases Addressed:

1. **Incorrect Barcode in Sample Sheet**:
   - In cases where an incorrect set of barcodes is provided for a sample, resulting in an empty FASTQ file, the pipeline previously halted. This was problematic when processing multiple samples (e.g., 99 valid samples and 1 with an incorrect barcode), as valid FASTQ files would remain in the workdir and not be moved to the outdir. With the proposed changes, the pipeline will continue to the end, allowing for the release of data for valid samples and logging the problematic sample for further investigation.

2. **Library Preparation Errors**:
   - Instances where library preparation for a specific sample is faulty can also lead to empty FASTQ files. The updated pipeline will now allow for continuous processing to the end, enabling users to utilize MultiQC outputs to identify which samples were problematic. The `invalid_fastqs.log` file will assist in pinpointing these samples for reprocessing or further laboratory investigation.