### PR TITLE
fix issue #5612 - boolean param to optionally log skipped fastqs

### DIFF
--- a/modules/nf-core/falco/main.nf
+++ b/modules/nf-core/falco/main.nf
@@ -22,7 +22,7 @@ process FALCO {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    if ( reads.toList().size() == 1 ) {
+    if ( reads.toList().findAll { it.size() > 200 }.size() == 1 ) {
         """
         falco $args --threads $task.cpus ${reads} -D ${prefix}_fastqc_data.txt -S ${prefix}_summary.txt -R ${prefix}_report.html
 

--- a/modules/nf-core/falco/main.nf
+++ b/modules/nf-core/falco/main.nf
@@ -17,15 +17,13 @@ process FALCO {
     path  "versions.yml"           , emit: versions
 
     when:
-    task.ext.when == null || task.ext.when
+    (task.ext.when == null || task.ext.when) && reads.every { it.size() > 20 }
 
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     if ( reads.toList().size() == 1 ) {
         """
-        echo "Running falco on the following reads: ${reads}"
-
         falco $args --threads $task.cpus ${reads} -D ${prefix}_fastqc_data.txt -S ${prefix}_summary.txt -R ${prefix}_report.html
 
         cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-core/falco/main.nf
+++ b/modules/nf-core/falco/main.nf
@@ -2,7 +2,6 @@ process FALCO {
     tag "$meta.id"
     label 'process_single'
 
-
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/falco:1.2.1--h867801b_3':
@@ -22,24 +21,39 @@ process FALCO {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    if ( reads.toList().findAll { it.size() > 200 }.size() == 1 ) {
-        """
-        falco $args --threads $task.cpus ${reads} -D ${prefix}_fastqc_data.txt -S ${prefix}_summary.txt -R ${prefix}_report.html
 
+    // Filter reads that are less than 20 bytes
+    def valid_reads = reads.findAll { it.size() > 20 }
+
+    if (valid_reads.isEmpty()) {
+        log.warn "No valid reads for ${meta.id} after filtering by size."
+        """
+        echo "No valid reads for ${meta.id}" > ${prefix}_no_valid_reads.txt
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
             falco:\$( falco --version | sed -e "s/falco//g" )
         END_VERSIONS
         """
     } else {
-        """
-        falco $args --threads $task.cpus ${reads}
+        if (valid_reads.size() == 1) {
+            """
+            falco $args --threads $task.cpus ${valid_reads[0]} -D ${prefix}_fastqc_data.txt -S ${prefix}_summary.txt -R ${prefix}_report.html
 
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            falco:\$( falco --version | sed -e "s/falco//g" )
-        END_VERSIONS
-        """
+            cat <<-END_VERSIONS > versions.yml
+            "${task.process}":
+                falco:\$( falco --version | sed -e "s/falco//g" )
+            END_VERSIONS
+            """
+        } else {
+            """
+            falco $args --threads $task.cpus ${valid_reads.join(' ')}
+
+            cat <<-END_VERSIONS > versions.yml
+            "${task.process}":
+                falco:\$( falco --version | sed -e "s/falco//g" )
+            END_VERSIONS
+            """
+        }
     }
 
     stub:

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,7 +18,7 @@ params {
 
     // Options: tooling
     skip_tools                  = []            // list [fastp, fastqc]
-    log_skipped_fastqs = true // Default to true for backward compatibility
+    log_empty_fastqs = true // Default to true for backward compatibility
 
     // MultiQC options
     multiqc_config             = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,6 +18,7 @@ params {
 
     // Options: tooling
     skip_tools                  = []            // list [fastp, fastqc]
+    log_skipped_fastqs = true // Default to true for backward compatibility
 
     // MultiQC options
     multiqc_config             = null
@@ -45,6 +46,7 @@ params {
     custom_config_base         = "https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}"
     config_profile_contact     = null
     config_profile_url         = null
+
 
     // Max resource options
     // Defaults only, expecting to be overwritten

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -20,6 +20,11 @@
                     "type": "string",
                     "default": null,
                     "description": "Comma-separated list of tools to skip (fastp,falco,multiqc)"
+                },
+                "log_skipped_fastqs": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Skip and Log into a file (invalid_fastqs.log) empty or invalid fastq files"
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -21,10 +21,10 @@
                     "default": null,
                     "description": "Comma-separated list of tools to skip (fastp,falco,multiqc)"
                 },
-                "log_skipped_fastqs": {
+                "log_empty_fastqs": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Skip and Log into a file (invalid_fastqs.log) empty or invalid fastq files"
+                    "description": "Skip and Log into a file (empty_fastqs.log) empty or invalid fastq files"
                 }
             }
         },

--- a/subworkflows/nf-core/bcl_demultiplex/main.nf
+++ b/subworkflows/nf-core/bcl_demultiplex/main.nf
@@ -8,7 +8,7 @@ include { BCLCONVERT } from "../../../modules/nf-core/bclconvert/main"
 include { BCL2FASTQ  } from "../../../modules/nf-core/bcl2fastq/main"
 
 // Define the log file path before the workflow starts
-def logFile = new File("${params.outdir}/skipped_fastqs.log")
+def logFile = file("${params.outdir}/skipped_fastqs.log")
 
 workflow BCL_DEMULTIPLEX {
     take:

--- a/subworkflows/nf-core/bcl_demultiplex/main.nf
+++ b/subworkflows/nf-core/bcl_demultiplex/main.nf
@@ -87,12 +87,12 @@ workflow BCL_DEMULTIPLEX {
 // This function appends a given text to a specified log file.
 // If the log file does not exist, it creates a new one.
 def appendToLogFile(String text, Path logFile) {
-    if (!logFile.exists()) {
-        logFile.createNewFile()
-    }
     // Convert the text to String if it's a GString
     String textToWrite = text.toString()
-    logFile << textToWrite + "\n" // Appends the text to the file with a new line
+    // Append text to the log file
+    logFile.withWriterAppend { writer ->
+        writer.println(textToWrite) // Appends the text to the file with a new line
+    }
 }
 
 // Add meta values to fastq channel and skip invalid FASTQ files

--- a/subworkflows/nf-core/bcl_demultiplex/main.nf
+++ b/subworkflows/nf-core/bcl_demultiplex/main.nf
@@ -86,7 +86,7 @@ workflow BCL_DEMULTIPLEX {
 
 // This function appends a given text to a specified log file.
 // If the log file does not exist, it creates a new one.
-def appendToLogFile(String text, File logFile) {
+def appendToLogFile(String text, Path logFile) {
     if (!logFile.exists()) {
         logFile.createNewFile()
     }

--- a/subworkflows/nf-core/bcl_demultiplex/main.nf
+++ b/subworkflows/nf-core/bcl_demultiplex/main.nf
@@ -7,14 +7,10 @@
 include { BCLCONVERT } from "../../../modules/nf-core/bclconvert/main"
 include { BCL2FASTQ  } from "../../../modules/nf-core/bcl2fastq/main"
 
-// Define the log file path before the workflow starts
-def logFile = file("${params.outdir}/empty_fastqs.log")
-
 workflow BCL_DEMULTIPLEX {
     take:
-        ch_flowcell     // [[id:"", lane:""],samplesheet.csv, path/to/bcl/files]
+        ch_flowcell     // [[id:"", lane:""], samplesheet.csv, path/to/bcl/files]
         demultiplexer   // bclconvert or bcl2fastq
-        log_empty_fastqs // parameter to control the logging of empty FASTQs to a file
 
     main:
         ch_versions      = Channel.empty()
@@ -68,7 +64,22 @@ workflow BCL_DEMULTIPLEX {
         }
 
         // Generate meta for each fastq
-        ch_fastq_with_meta = generate_fastq_meta(ch_fastq, logFile)
+        ch_fastq_with_meta = ch_fastq
+            // reshapes the channel from a single emit of [meta, [fastq, fastq, fastq...]]
+            // to emits per fastq file like [meta, fastq]
+            .transpose()
+            .map{ fc_meta, fastq ->
+                def meta = [
+                    "id": fastq.getSimpleName().toString() - ~/_R[0-9]_001.*$/,
+                    "samplename": fastq.getSimpleName().toString() - ~/_S[0-9]+.*$/,
+                    "fcid": fc_meta.id,
+                    "lane": fc_meta.lane,
+                ]
+                return [meta, fastq]
+            }
+            // Group by the meta id so that we can find mate pairs if they exist
+            .groupTuple(by: [0])
+            .dump(tag: 'fastq_with_meta')
 
     emit:
         fastq    = ch_fastq_with_meta
@@ -76,100 +87,4 @@ workflow BCL_DEMULTIPLEX {
         stats    = ch_stats
         interop  = ch_interop
         versions = ch_versions
-}
-
-/*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    FUNCTIONS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*/
-
-// This function appends a given text to a specified log file.
-// If the log file does not exist, it creates a new one.
-def appendToLogFile(String text, Path logFile) {
-    // Convert the text to String if it's a GString
-    String textToWrite = text.toString()
-    // Append text to the log file
-    logFile.withWriterAppend { writer ->
-        writer.println(textToWrite) // Appends the text to the file with a new line
-    }
-}
-
-// Add meta values to fastq channel and skip invalid FASTQ files
-def generate_fastq_meta(ch_reads, logFile) {
-    // Create a tuple with the meta.id and the fastq
-    ch_reads.transpose().map { fc_meta, fastq ->
-        // Check if the FASTQ file is empty or has invalid content
-        def isValid = fastq.withInputStream { is ->
-            new java.util.zip.GZIPInputStream(is).withReader('ASCII') { reader ->
-                def line = reader.readLine()
-                line != null && line.startsWith('@')
-            }
-        }
-
-        def meta = null
-        if (isValid) {
-            meta = [
-                "id": fastq.getSimpleName().toString() - ~/_R[0-9]_001.*$/,
-                "samplename": fastq.getSimpleName().toString() - ~/_S[0-9]+.*$/,
-                "readgroup": [:],
-                "fcid": fc_meta.id,
-                "lane": fc_meta.lane
-            ]
-            meta.readgroup = readgroup_from_fastq(fastq)
-            meta.readgroup.SM = meta.samplename
-        } else {
-            if (params.log_empty_fastqs) {
-                appendToLogFile(
-                    "Empty or invalid FASTQ file: ${fastq}",
-                    logFile
-                )
-            }
-            fastq = null
-        }
-
-        return [meta, fastq]
-    }.filter { it[0] != null }
-    // Group by meta.id for PE samples
-    .groupTuple(by: [0])
-    // Add meta.single_end
-    .map { meta, fastq ->
-        if (meta != null) {
-            meta.single_end = fastq.size() == 1
-        }
-        return [meta, fastq.flatten()]
-    }
-}
-
-// https://github.com/nf-core/sarek/blob/7ba61bde8e4f3b1932118993c766ed33b5da465e/workflows/sarek.nf#L1014-L1040
-def readgroup_from_fastq(path) {
-    // expected format:
-    // xx:yy:FLOWCELLID:LANE:... (seven fields)
-
-    def line
-
-    path.withInputStream {
-        InputStream gzipStream = new java.util.zip.GZIPInputStream(it)
-        Reader decoder = new InputStreamReader(gzipStream, 'ASCII')
-        BufferedReader buffered = new BufferedReader(decoder)
-        line = buffered.readLine()
-    }
-    assert line.startsWith('@')
-    line = line.substring(1)
-    def fields = line.split(':')
-    def rg = [:]
-
-    // CASAVA 1.8+ format, from  https://support.illumina.com/help/BaseSpace_OLH_009008/Content/Source/Informatics/BS/FileFormat_FASTQ-files_swBS.htm
-    // "@<instrument>:<run number>:<flowcell ID>:<lane>:<tile>:<x-pos>:<y-pos>:<UMI> <read>:<is filtered>:<control number>:<index>"
-    sequencer_serial = fields[0]
-    run_nubmer       = fields[1]
-    fcid             = fields[2]
-    lane             = fields[3]
-    index            = fields[-1] =~ /[GATC+-]/ ? fields[-1] : ""
-
-    rg.ID = [fcid,lane].join(".")
-    rg.PU = [fcid, lane, index].findAll().join(".")
-    rg.PL = "ILLUMINA"
-
-    return rg
 }

--- a/subworkflows/nf-core/bcl_demultiplex/main.nf
+++ b/subworkflows/nf-core/bcl_demultiplex/main.nf
@@ -8,13 +8,13 @@ include { BCLCONVERT } from "../../../modules/nf-core/bclconvert/main"
 include { BCL2FASTQ  } from "../../../modules/nf-core/bcl2fastq/main"
 
 // Define the log file path before the workflow starts
-def logFile = file("${params.outdir}/skipped_fastqs.log")
+def logFile = file("${params.outdir}/empty_fastqs.log")
 
 workflow BCL_DEMULTIPLEX {
     take:
         ch_flowcell     // [[id:"", lane:""],samplesheet.csv, path/to/bcl/files]
         demultiplexer   // bclconvert or bcl2fastq
-        log_skipped_fastqs // New parameter to control logging of empty FASTQ files
+        log_empty_fastqs // parameter to control the logging of empty FASTQs to a file
 
     main:
         ch_versions      = Channel.empty()
@@ -119,7 +119,7 @@ def generate_fastq_meta(ch_reads, logFile) {
             meta.readgroup = readgroup_from_fastq(fastq)
             meta.readgroup.SM = meta.samplename
         } else {
-            if (params.log_skipped_fastqs) {
+            if (params.log_empty_fastqs) {
                 appendToLogFile(
                     "Empty or invalid FASTQ file: ${fastq}",
                     logFile

--- a/workflows/demultiplex.nf
+++ b/workflows/demultiplex.nf
@@ -194,7 +194,7 @@ workflow DEMULTIPLEX {
     // Split file list into separate channels entries and generate a checksum for each
     // Run MD5SUM on all FASTQ files (including potentially empty ones)
     if (!("md5sum" in skip_tools)) {
-        MD5SUM(ch_raw_fastq.map { meta, fastq -> fastq })
+        MD5SUM(ch_raw_fastq.flatten().map { it -> it[1] })
         ch_versions = ch_versions.mix(MD5SUM.out.versions)
     }
 

--- a/workflows/demultiplex.nf
+++ b/workflows/demultiplex.nf
@@ -113,7 +113,7 @@ workflow DEMULTIPLEX {
         case ['bcl2fastq', 'bclconvert']:
             // SUBWORKFLOW: illumina
             // Runs when "demultiplexer" is set to "bclconvert" or "bcl2fastq"
-            BCL_DEMULTIPLEX( ch_flowcells, demultiplexer, params.log_skipped_fastqs )
+            BCL_DEMULTIPLEX( ch_flowcells, demultiplexer, params.log_empty_fastqs )
             ch_raw_fastq = ch_raw_fastq.mix( BCL_DEMULTIPLEX.out.fastq )
             ch_multiqc_files = ch_multiqc_files.mix( BCL_DEMULTIPLEX.out.reports.map { meta, report -> return report} )
             ch_multiqc_files = ch_multiqc_files.mix( BCL_DEMULTIPLEX.out.stats.map   { meta, stats  -> return stats } )

--- a/workflows/demultiplex.nf
+++ b/workflows/demultiplex.nf
@@ -163,9 +163,11 @@ workflow DEMULTIPLEX {
 
     ch_fastq_to_qc = ch_raw_fastq
 
-   // Filter tar.gz files that are not empty and log the filtered files
+    // Filter tar.gz files that are not empty and log the filtered files
     ch_fastq_to_qc = ch_fastq_to_qc.filter { file ->
-        if (file.size() > 200) {
+        def size = file.size()
+        println "Checking file: ${file}, size: ${size} bytes"
+        if (size > 200) {
             println "File passed size check: ${file}"
             return true
         } else {
@@ -173,6 +175,9 @@ workflow DEMULTIPLEX {
             return false
         }
     }
+
+    // Check the content of ch_fastq_to_qc before passing to FALCO
+    ch_fastq_to_qc.view { "Files to be processed by FALCO: ${it}" }
 
     // MODULE: fastp
     if (!("fastp" in skip_tools)){

--- a/workflows/demultiplex.nf
+++ b/workflows/demultiplex.nf
@@ -161,7 +161,16 @@ workflow DEMULTIPLEX {
     // RUN QC and TRIMMING
     //
 
-    ch_fastq_to_qc = ch_raw_fastq
+    // Check if the fastq files are valid (not empty, gzipped, and starts with @)
+    ch_fastq_to_qc = ch_raw_fastq.filter { meta, fastq ->
+        def isValid = fastq.withInputStream { is ->
+            new java.util.zip.GZIPInputStream(is).withReader('ASCII') { reader ->
+                def line = reader.readLine()
+                line != null && line.startsWith('@')
+            }
+        }
+        isValid
+    }
 
     // MODULE: fastp
     if (!("fastp" in skip_tools)){

--- a/workflows/demultiplex.nf
+++ b/workflows/demultiplex.nf
@@ -157,28 +157,11 @@ workflow DEMULTIPLEX {
     }
     ch_raw_fastq.dump(tag: "DEMULTIPLEX::Demultiplexed Fastq",{FormattingService.prettyFormat(it)})
 
-        //
+    //
     // RUN QC and TRIMMING
     //
 
-    // Flatten nested lists and check file sizes
-    ch_fastq_to_qc = ch_raw_fastq.flatten()
-        .map { file ->
-            def size = file.size()
-            println "File path: ${file}, File size: ${size} bytes"
-            return [file, size]
-        }
-        .filter { item ->
-            def (file, size) = item
-            if (size > 200) {
-                println "File passed size check: ${file}"
-                return true
-            } else {
-                println "File failed size check: ${file}"
-                return false
-            }
-        }
-        .map { item -> item[0] }  // Extract file path only after filtering
+    ch_fastq_to_qc = ch_raw_fastq
 
     // MODULE: fastp
     if (!("fastp" in skip_tools)){

--- a/workflows/demultiplex.nf
+++ b/workflows/demultiplex.nf
@@ -161,8 +161,10 @@ workflow DEMULTIPLEX {
     // RUN QC and TRIMMING
     //
 
-    // Check if the fastq files are valid (not empty, gzipped, and starts with @)
-    ch_fastq_to_qc = ch_raw_fastq.flatten().filter { meta, fastq ->
+    ch_fastq_to_qc = ch_raw_fastq
+
+    // Filter valid FASTQ files for FALCO
+    ch_valid_fastq = ch_raw_fastq.flatten().filter { meta, fastq ->
         def isValid = fastq.withInputStream { is ->
             new java.util.zip.GZIPInputStream(is).withReader('ASCII') { reader ->
                 def line = reader.readLine()
@@ -170,8 +172,7 @@ workflow DEMULTIPLEX {
             }
         }
         isValid
-    }
-
+}
     // MODULE: fastp
     if (!("fastp" in skip_tools)){
             FASTP(ch_raw_fastq, [], [], [])
@@ -183,16 +184,17 @@ workflow DEMULTIPLEX {
     }
 
     // MODULE: falco, drop in replacement for fastqc
-    if (!("falco" in skip_tools)){
-        FALCO(ch_fastq_to_qc)
-        ch_multiqc_files = ch_multiqc_files.mix( FALCO.out.txt.map { meta, txt -> return txt} )
+    // Run falco on valid FASTQ files only
+    if (!("falco" in skip_tools)) {
+        FALCO(ch_valid_fastq)
+        ch_multiqc_files = ch_multiqc_files.mix(FALCO.out.txt.map { meta, txt -> txt })
         ch_versions = ch_versions.mix(FALCO.out.versions)
-    }
-
+}
     // MODULE: md5sum
     // Split file list into separate channels entries and generate a checksum for each
-    if (!("md5sum" in skip_tools)){
-        MD5SUM(ch_fastq_to_qc.transpose())
+    // Run MD5SUM on all FASTQ files (including potentially empty ones)
+    if (!("md5sum" in skip_tools)) {
+        MD5SUM(ch_raw_fastq.map { meta, fastq -> fastq })
         ch_versions = ch_versions.mix(MD5SUM.out.versions)
     }
 

--- a/workflows/demultiplex.nf
+++ b/workflows/demultiplex.nf
@@ -163,9 +163,15 @@ workflow DEMULTIPLEX {
 
     ch_fastq_to_qc = ch_raw_fastq
 
-    // Filter tar.gz files that are not empty
+   // Filter tar.gz files that are not empty and log the filtered files
     ch_fastq_to_qc = ch_fastq_to_qc.filter { file ->
-        file.size() > 200
+        if (file.size() > 200) {
+            println "File passed size check: ${file}"
+            return true
+        } else {
+            println "File failed size check: ${file}"
+            return false
+        }
     }
 
     // MODULE: fastp

--- a/workflows/demultiplex.nf
+++ b/workflows/demultiplex.nf
@@ -1,32 +1,6 @@
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    PRINT PARAMS SUMMARY
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*/
-
-include { paramsSummaryLog; paramsSummaryMap } from 'plugin/nf-validation'
-
-def logo = NfcoreTemplate.logo(workflow, params.monochrome_logs)
-def citation = '\n' + WorkflowMain.citation(workflow) + '\n'
-def summary_params = paramsSummaryMap(workflow)
-
-// Print parameter summary log to screen
-log.info logo + paramsSummaryLog(workflow) + citation
-
-/*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    CONFIG FILES
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*/
-
-ch_multiqc_config          = Channel.fromPath("$projectDir/assets/multiqc_config.yml", checkIfExists: true)
-ch_multiqc_custom_config   = params.multiqc_config ? Channel.fromPath( params.multiqc_config, checkIfExists: true ) : Channel.empty()
-ch_multiqc_logo            = params.multiqc_logo   ? Channel.fromPath( params.multiqc_logo, checkIfExists: true ) : Channel.empty()
-ch_multiqc_custom_methods_description = params.multiqc_methods_description ? file(params.multiqc_methods_description, checkIfExists: true) : file("$projectDir/assets/methods_description_template.yml", checkIfExists: true)
-
-/*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    IMPORT LOCAL MODULES/SUBWORKFLOWS
+    IMPORT MODULES / SUBWORKFLOWS / FUNCTIONS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
@@ -38,21 +12,22 @@ include { BASES_DEMULTIPLEX    } from '../subworkflows/local/bases_demultiplex/m
 include { FQTK_DEMULTIPLEX     } from '../subworkflows/local/fqtk_demultiplex/main'
 include { SINGULAR_DEMULTIPLEX } from '../subworkflows/local/singular_demultiplex/main'
 
-/*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    IMPORT NF-CORE MODULES/SUBWORKFLOWS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*/
-
 //
 // MODULE: Installed directly from nf-core/modules
 //
-include { CUSTOM_DUMPSOFTWAREVERSIONS   } from '../modules/nf-core/custom/dumpsoftwareversions/main'
 include { FASTP                         } from '../modules/nf-core/fastp/main'
 include { FALCO                         } from '../modules/nf-core/falco/main'
 include { MULTIQC                       } from '../modules/nf-core/multiqc/main'
 include { UNTAR                         } from '../modules/nf-core/untar/main'
 include { MD5SUM                        } from '../modules/nf-core/md5sum/main'
+
+//
+// FUNCTION
+//
+include { paramsSummaryMap       } from 'plugin/nf-validation'
+include { paramsSummaryMultiqc   } from '../subworkflows/nf-core/utils_nfcore_pipeline'
+include { softwareVersionsToYAML } from '../subworkflows/nf-core/utils_nfcore_pipeline'
+include { methodsDescriptionText } from '../subworkflows/local/utils_nfcore_demultiplex_pipeline'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -60,59 +35,53 @@ include { MD5SUM                        } from '../modules/nf-core/md5sum/main'
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-// Info required for completion email and summary
-def multiqc_report = []
-
 workflow DEMULTIPLEX {
+
+    take:
+    ch_samplesheet // channel: samplesheet read in from --input
+
+    main:
     // Value inputs
     demultiplexer = params.demultiplexer                                   // string: bases2fastq, bcl2fastq, bclconvert, fqtk, sgdemux
     trim_fastq    = params.trim_fastq                                      // boolean: true, false
     skip_tools    = params.skip_tools ? params.skip_tools.split(',') : []  // list: [falco, fastp, multiqc]
 
     // Channel inputs
-    ch_input = file(params.input)
     ch_versions = Channel.empty()
     ch_multiqc_files = Channel.empty()
+    ch_multiqc_reports = Channel.empty()
 
-    // Sanitize inputs and separate input types
-    // FQTK's input contains an extra column 'per_flowcell_manifest' so it is handled seperately
-    // For reference:
-    //      https://raw.githubusercontent.com/nf-core/test-datasets/demultiplex/samplesheet/1.3.0/fqtk-samplesheet.csv VS
-    //      https://raw.githubusercontent.com/nf-core/test-datasets/demultiplex/samplesheet/1.3.0/sgdemux-samplesheet.csv
+    // Convenience
+    ch_samplesheet.dump(tag: 'DEMULTIPLEX::inputs', {FormattingService.prettyFormat(it)})
+
+    // Split flowcells into separate channels containg run as tar and run as path
+    // https://nextflow.slack.com/archives/C02T98A23U7/p1650963988498929
     if (demultiplexer == 'fqtk'){
-        ch_inputs = extract_csv_fqtk(ch_input)
 
-        ch_inputs.dump(tag: 'DEMULTIPLEX::inputs',{FormattingService.prettyFormat(it)})
-
-        // Split flowcells into separate channels containg run as tar and run as path
-        // https://nextflow.slack.com/archives/C02T98A23U7/p1650963988498929
-        ch_flowcells = ch_inputs
-            .branch { meta, samplesheet, run, manifest ->
-                tar: run.toString().endsWith('.tar.gz')
+        ch_flowcells = ch_samplesheet
+            .branch { meta, samplesheet, flowcell, per_flowcell_manifest ->
+                tar: flowcell.toString().endsWith('.tar.gz')
                 dir: true
             }
-
         ch_flowcells_tar = ch_flowcells.tar
-            .multiMap { meta, samplesheet, run, manifest ->
-                samplesheets: [ meta, samplesheet, manifest ]
-                run_dirs: [ meta, run ]
+            .multiMap { meta, samplesheet, flowcell, per_flowcell_manifest ->
+                samplesheets: [ meta, samplesheet, per_flowcell_manifest ]
+                run_dirs: [ meta, flowcell ]
             }
     } else {
-        ch_inputs = extract_csv(ch_input)
-        ch_inputs.dump(tag: 'DEMULTIPLEX::inputs',{FormattingService.prettyFormat(it)})
 
-        // Split flowcells into separate channels containg run as tar and run as path
-        // https://nextflow.slack.com/archives/C02T98A23U7/p1650963988498929
-        ch_flowcells = ch_inputs
-            .branch { meta, samplesheet, run ->
-                tar: run.toString().endsWith('.tar.gz')
+        ch_flowcells = ch_samplesheet
+            .map { meta, samplesheet, flowcell, per_flowcell_manifest ->
+                [ meta, samplesheet, flowcell ]
+            }
+            .branch { meta, samplesheet, flowcell ->
+                tar: flowcell.toString().endsWith('.tar.gz')
                 dir: true
             }
-
         ch_flowcells_tar = ch_flowcells.tar
-            .multiMap { meta, samplesheet, run ->
+            .multiMap { meta, samplesheet, flowcell ->
                 samplesheets: [ meta, samplesheet ]
-                run_dirs: [ meta, run ]
+                run_dirs: [ meta, flowcell ]
             }
     }
 
@@ -166,11 +135,11 @@ workflow DEMULTIPLEX {
             // [example_R1.fastq.gz, 150T, ./work/98/30bc..78y/fastqs/]
             fastqs_with_paths = fastq_read_structure.combine(UNTAR.out.untar.collect{it[1]}).toList()
 
-            // Format ch_input like so:
+            // Format ch_samplesheet like so:
             // [[meta:id], <path to sample names and barcodes in tsv: path>, [<fastq name: string>, <read structure: string>, <path to fastqs: path>]]]
-            ch_input = ch_flowcells.merge( fastqs_with_paths ) { a,b -> tuple(a[0], a[1], b)}
+            ch_samplesheet = ch_flowcells.merge( fastqs_with_paths ) { a,b -> tuple(a[0], a[1], b)}
 
-            FQTK_DEMULTIPLEX ( ch_input )
+            FQTK_DEMULTIPLEX ( ch_samplesheet )
             ch_raw_fastq = ch_raw_fastq.mix(FQTK_DEMULTIPLEX.out.fastq)
             ch_multiqc_files = ch_multiqc_files.mix(FQTK_DEMULTIPLEX.out.metrics.map { meta, metrics -> return metrics} )
             ch_versions = ch_versions.mix(FQTK_DEMULTIPLEX.out.versions)
@@ -213,25 +182,53 @@ workflow DEMULTIPLEX {
 
     // MODULE: md5sum
     // Split file list into separate channels entries and generate a checksum for each
-    MD5SUM(ch_fastq_to_qc.transpose())
+    if (!("md5sum" in skip_tools)){
+        MD5SUM(ch_fastq_to_qc.transpose())
+        ch_versions = ch_versions.mix(MD5SUM.out.versions)
+    }
 
-    // DUMP SOFTWARE VERSIONS
-    CUSTOM_DUMPSOFTWAREVERSIONS (
-        ch_versions.unique().collectFile(name: 'collated_versions.yml')
-    )
+    //
+    // Collate and save software versions
+    //
+    softwareVersionsToYAML(ch_versions)
+        .collectFile(
+            storeDir: "${params.outdir}/pipeline_info",
+            name: 'nf_core_pipeline_software_mqc_versions.yml',
+            sort: true,
+            newLine: true
+        ).set { ch_collated_versions }
 
     // MODULE: MultiQC
     if (!("multiqc" in skip_tools)){
-        workflow_summary    = WorkflowDemultiplex.paramsSummaryMultiqc(workflow, summary_params)
-        ch_workflow_summary = Channel.value(workflow_summary)
+        ch_multiqc_files.collect().dump(tag: "multiqc_files",{FormattingService.prettyFormat(it)})
 
-        methods_description    = WorkflowDemultiplex.methodsDescriptionText(workflow, ch_multiqc_custom_methods_description, params)
-        ch_methods_description = Channel.value(methods_description)
+        ch_multiqc_config        = Channel.fromPath(
+            "$projectDir/assets/multiqc_config.yml", checkIfExists: true)
+        ch_multiqc_custom_config = params.multiqc_config ?
+            Channel.fromPath(params.multiqc_config, checkIfExists: true) :
+            Channel.empty()
+        ch_multiqc_logo= params.multiqc_logo ?
+            Channel.fromPath(params.multiqc_logo, checkIfExists: true) :
+            Channel.empty()
+        summary_params      = paramsSummaryMap(
+            workflow, parameters_schema: "nextflow_schema.json")
+        ch_workflow_summary = Channel.value(paramsSummaryMultiqc(summary_params))
 
-        ch_multiqc_files = ch_multiqc_files.mix(ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
-        ch_multiqc_files = ch_multiqc_files.mix(ch_methods_description.collectFile(name: 'methods_description_mqc.yaml'))
-        ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
-        ch_multiqc_files.collect().dump(tag: "DEMULTIPLEX::MultiQC files",{FormattingService.prettyFormat(it)})
+        ch_multiqc_custom_methods_description = params.multiqc_methods_description ?
+            file(params.multiqc_methods_description, checkIfExists: true) :
+            file("$projectDir/assets/methods_description_template.yml", checkIfExists: true)
+        ch_methods_description                = Channel.value(
+            methodsDescriptionText(ch_multiqc_custom_methods_description))
+
+        ch_multiqc_files = ch_multiqc_files.mix(
+            ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
+        ch_multiqc_files = ch_multiqc_files.mix(ch_collated_versions)
+        ch_multiqc_files = ch_multiqc_files.mix(
+            ch_methods_description.collectFile(
+                name: 'methods_description_mqc.yaml',
+                sort: true
+            )
+        )
 
         MULTIQC (
             ch_multiqc_files.collect(),
@@ -239,197 +236,15 @@ workflow DEMULTIPLEX {
             ch_multiqc_custom_config.toList(),
             ch_multiqc_logo.toList()
         )
-        multiqc_report = MULTIQC.out.report.toList()
-    }
-}
-
-/*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    COMPLETION EMAIL AND SUMMARY
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*/
-
-workflow.onComplete {
-    if (params.email || params.email_on_fail) {
-        NfcoreTemplate.email(workflow, params, summary_params, projectDir, log, multiqc_report)
-    }
-    NfcoreTemplate.dump_parameters(workflow, params)
-    NfcoreTemplate.summary(workflow, params, log)
-    if (params.hook_url) {
-        NfcoreTemplate.IM_notification(workflow, params, summary_params, projectDir, log)
-    }
-}
-
-workflow.onError {
-    if (workflow.errorReport.contains("Process requirement exceeds available memory")) {
-        println("🛑 Default resources exceed availability 🛑 ")
-        println("💡 See here on how to configure pipeline: https://nf-co.re/docs/usage/configuration#tuning-workflow-resources 💡")
-    }
-}
-
-/*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    FUNCTIONS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*/
-// Extract information (meta data + file(s)) from csv file(s)
-def extract_csv(input_csv, input_schema=null) {
-
-    // Flowcell Sheet schema
-    // Possible values for the "content" column: [meta, path, number, string, bool]
-    if(input_schema == null){
-        def default_input_schema = [
-            'columns': [
-                'id': [
-                    'content': 'meta',
-                    'meta_name': 'id',
-                    'pattern': '',
-                ],
-                'samplesheet': [
-                    'content': 'path',
-                    'pattern': '^.*.csv$',
-                ],
-                'lane': [
-                    'content': 'meta',
-                    'meta_name': 'lane',
-                    'pattern': '',
-                ],
-                'flowcell': [
-                    'content': 'path',
-                    'pattern': '',
-                ],
-            ],
-            required: ['id','flowcell', 'samplesheet'],
-        ]
-        input_schema = default_input_schema
-    }
-    // Don't change these variables
-    def row_count = 1
-    def all_columns = input_schema.columns.keySet().collect()
-    def mandatory_columns = input_schema.required
-
-    // Header checks
-    Channel.value(input_csv).splitCsv(strip:true).first().map({ row ->
-
-        if(row != all_columns) {
-            def commons = all_columns.intersect(row)
-            def diffs = all_columns.plus(row)
-            diffs.removeAll(commons)
-
-            if(diffs.size() > 0){
-                def missing_columns = []
-                def wrong_columns = []
-                for(diff : diffs){
-                    diff in all_columns ? missing_columns.add(diff) : wrong_columns.add(diff)
-                }
-                if(missing_columns.size() > 0){
-                    error "[Samplesheet Error] The column(s) $missing_columns is/are not present. The header should look like: $all_columns"
-                }
-                else {
-                    error "[Samplesheet Error] The column(s) $wrong_columns should not be in the header. The header should look like: $all_columns"
-                }
-            }
-            else {
-                error "[Samplesheet Error] The columns $row are not in the right order. The header should look like: $all_columns"
-            }
-
-        }
-    })
-
-    // Field checks + returning the channels
-    Channel.value(input_csv).splitCsv(header:true, strip:true).map({ row ->
-
-        row_count++
-
-        // Check the mandatory columns
-        def missing_mandatory_columns = []
-        for(column : mandatory_columns) {
-            row[column] ?: missing_mandatory_columns.add(column)
-        }
-        if(missing_mandatory_columns.size > 0){
-            error "[Samplesheet Error] The mandatory column(s) $missing_mandatory_columns is/are empty on line $row_count"
-        }
-
-        def output = []
-        def meta = [:]
-        for(col : input_schema.columns) {
-            key = col.key
-            content = row[key]
-
-            if(!(content ==~ col.value['pattern']) && col.value['pattern'] != '' && content != '') {
-                error "[Samplesheet Error] The content of column '$key' on line $row_count does not match the pattern '${col.value['pattern']}'"
-            }
-
-            if(col.value['content'] == 'path'){
-                output.add(content ? file(content, checkIfExists:true) : col.value['default'] ?: [])
-            }
-            else if(col.value['content'] == 'meta'){
-                for(meta_name : col.value['meta_name'].split(",")){
-                    meta[meta_name] = content != '' ? content.replace(' ', '_') : col.value['default'] ?: null
-                }
-            }
-        }
-
-        output.add(0, meta)
-        return output
-    })
-}
-
-// Parse flowcell input map
-def parse_flowcell_csv(row) {
-    def meta = [:]
-    meta.id   = row.id.toString()
-    meta.lane = null
-    if (row.containsKey("lane") && row.lane ) {
-        meta.lane = row.lane.toInteger()
+        ch_multiqc_reports = ch_multiqc_reports.mix(MULTIQC.out.report)
     }
 
-    def flowcell        = file(row.flowcell, checkIfExists: true)
-    def samplesheet     = file(row.samplesheet, checkIfExists: true)
-    return [meta, samplesheet, flowcell]
+    emit:
+    multiqc_report = ch_multiqc_reports // channel: /path/to/multiqc_report.html
+    versions       = ch_versions        // channel: [ path(versions.yml) ]
+
 }
 
-/*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    FUNCTIONS FOR FQTK
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*/
-
-// Extract information (meta data + file(s)) from csv file(s)
-def extract_csv_fqtk(input_csv) {
-
-    // Flowcell Sheet schema
-    // Possible values for the "content" column: [meta, path, number, string, bool]
-    def input_schema = [
-        'columns': [
-            'id': [
-                'content': 'meta',
-                'meta_name': 'id',
-                'pattern': '',
-            ],
-            'samplesheet': [
-                'content': 'path',
-                'pattern': '^.*.csv$',
-            ],
-            'lane': [
-                'content': 'meta',
-                'meta_name': 'lane',
-                'pattern': '',
-            ],
-            'flowcell': [
-                'content': 'path',
-                'pattern': '',
-            ],
-            'per_flowcell_manifest': [
-                'content': 'path',
-                'pattern': '',
-            ]
-        ],
-        required: ['id','flowcell', 'samplesheet', 'per_flowcell_manifest'],
-    ]
-
-    return extract_csv(input_csv, input_schema)
-}
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/workflows/demultiplex.nf
+++ b/workflows/demultiplex.nf
@@ -54,7 +54,7 @@ workflow DEMULTIPLEX {
     // Convenience
     ch_samplesheet.dump(tag: 'DEMULTIPLEX::inputs', {FormattingService.prettyFormat(it)})
 
-    // Split flowcells into separate channels containg run as tar and run as path
+    // Split flowcells into separate channels containing run as tar and run as path
     // https://nextflow.slack.com/archives/C02T98A23U7/p1650963988498929
     if (demultiplexer == 'fqtk'){
 
@@ -84,7 +84,7 @@ workflow DEMULTIPLEX {
 
     // MODULE: untar
     // Runs when run_dir is a tar archive
-    // Except for bclconvert and bcl2fastq for wich we untar in the process
+    // Except for bclconvert and bcl2fastq for which we untar in the process
     // Re-join the metadata and the untarred run directory with the samplesheet
 
     if (demultiplexer in ['bclconvert', 'bcl2fastq']) ch_flowcells_tar_merged = ch_flowcells_tar.samplesheets.join(ch_flowcells_tar.run_dirs, failOnMismatch:true, failOnDuplicate:true)
@@ -113,7 +113,7 @@ workflow DEMULTIPLEX {
         case ['bcl2fastq', 'bclconvert']:
             // SUBWORKFLOW: illumina
             // Runs when "demultiplexer" is set to "bclconvert" or "bcl2fastq"
-            BCL_DEMULTIPLEX( ch_flowcells, demultiplexer )
+            BCL_DEMULTIPLEX( ch_flowcells, demultiplexer, params.log_skipped_fastqs )
             ch_raw_fastq = ch_raw_fastq.mix( BCL_DEMULTIPLEX.out.fastq )
             ch_multiqc_files = ch_multiqc_files.mix( BCL_DEMULTIPLEX.out.reports.map { meta, report -> return report} )
             ch_multiqc_files = ch_multiqc_files.mix( BCL_DEMULTIPLEX.out.stats.map   { meta, stats  -> return stats } )
@@ -241,7 +241,6 @@ workflow DEMULTIPLEX {
     versions       = ch_versions        // channel: [ path(versions.yml) ]
 
 }
-
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/workflows/demultiplex.nf
+++ b/workflows/demultiplex.nf
@@ -162,7 +162,7 @@ workflow DEMULTIPLEX {
     //
 
     // Check if the fastq files are valid (not empty, gzipped, and starts with @)
-    ch_fastq_to_qc = ch_raw_fastq.filter { meta, fastq ->
+    ch_fastq_to_qc = ch_raw_fastq.flatten().filter { meta, fastq ->
         def isValid = fastq.withInputStream { is ->
             new java.util.zip.GZIPInputStream(is).withReader('ASCII') { reader ->
                 def line = reader.readLine()

--- a/workflows/demultiplex.nf
+++ b/workflows/demultiplex.nf
@@ -1,6 +1,32 @@
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    IMPORT MODULES / SUBWORKFLOWS / FUNCTIONS
+    PRINT PARAMS SUMMARY
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+include { paramsSummaryLog; paramsSummaryMap } from 'plugin/nf-validation'
+
+def logo = NfcoreTemplate.logo(workflow, params.monochrome_logs)
+def citation = '\n' + WorkflowMain.citation(workflow) + '\n'
+def summary_params = paramsSummaryMap(workflow)
+
+// Print parameter summary log to screen
+log.info logo + paramsSummaryLog(workflow) + citation
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    CONFIG FILES
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+ch_multiqc_config          = Channel.fromPath("$projectDir/assets/multiqc_config.yml", checkIfExists: true)
+ch_multiqc_custom_config   = params.multiqc_config ? Channel.fromPath( params.multiqc_config, checkIfExists: true ) : Channel.empty()
+ch_multiqc_logo            = params.multiqc_logo   ? Channel.fromPath( params.multiqc_logo, checkIfExists: true ) : Channel.empty()
+ch_multiqc_custom_methods_description = params.multiqc_methods_description ? file(params.multiqc_methods_description, checkIfExists: true) : file("$projectDir/assets/methods_description_template.yml", checkIfExists: true)
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    IMPORT LOCAL MODULES/SUBWORKFLOWS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
@@ -12,22 +38,21 @@ include { BASES_DEMULTIPLEX    } from '../subworkflows/local/bases_demultiplex/m
 include { FQTK_DEMULTIPLEX     } from '../subworkflows/local/fqtk_demultiplex/main'
 include { SINGULAR_DEMULTIPLEX } from '../subworkflows/local/singular_demultiplex/main'
 
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    IMPORT NF-CORE MODULES/SUBWORKFLOWS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
 //
 // MODULE: Installed directly from nf-core/modules
 //
+include { CUSTOM_DUMPSOFTWAREVERSIONS   } from '../modules/nf-core/custom/dumpsoftwareversions/main'
 include { FASTP                         } from '../modules/nf-core/fastp/main'
 include { FALCO                         } from '../modules/nf-core/falco/main'
 include { MULTIQC                       } from '../modules/nf-core/multiqc/main'
 include { UNTAR                         } from '../modules/nf-core/untar/main'
 include { MD5SUM                        } from '../modules/nf-core/md5sum/main'
-
-//
-// FUNCTION
-//
-include { paramsSummaryMap       } from 'plugin/nf-validation'
-include { paramsSummaryMultiqc   } from '../subworkflows/nf-core/utils_nfcore_pipeline'
-include { softwareVersionsToYAML } from '../subworkflows/nf-core/utils_nfcore_pipeline'
-include { methodsDescriptionText } from '../subworkflows/local/utils_nfcore_demultiplex_pipeline'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -35,56 +60,65 @@ include { methodsDescriptionText } from '../subworkflows/local/utils_nfcore_demu
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
+// Info required for completion email and summary
+def multiqc_report = []
+
 workflow DEMULTIPLEX {
-
-    take:
-    ch_samplesheet // channel: samplesheet read in from --input
-
-    main:
     // Value inputs
     demultiplexer = params.demultiplexer                                   // string: bases2fastq, bcl2fastq, bclconvert, fqtk, sgdemux
     trim_fastq    = params.trim_fastq                                      // boolean: true, false
     skip_tools    = params.skip_tools ? params.skip_tools.split(',') : []  // list: [falco, fastp, multiqc]
 
     // Channel inputs
+    ch_input = file(params.input)
     ch_versions = Channel.empty()
     ch_multiqc_files = Channel.empty()
-    ch_multiqc_reports = Channel.empty()
 
-    // Convenience
-    ch_samplesheet.dump(tag: 'DEMULTIPLEX::inputs', {FormattingService.prettyFormat(it)})
-
-    // Split flowcells into separate channels containing run as tar and run as path
-    // https://nextflow.slack.com/archives/C02T98A23U7/p1650963988498929
+    // Sanitize inputs and separate input types
+    // FQTK's input contains an extra column 'per_flowcell_manifest' so it is handled seperately
+    // For reference:
+    //      https://raw.githubusercontent.com/nf-core/test-datasets/demultiplex/samplesheet/1.3.0/fqtk-samplesheet.csv VS
+    //      https://raw.githubusercontent.com/nf-core/test-datasets/demultiplex/samplesheet/1.3.0/sgdemux-samplesheet.csv
     if (demultiplexer == 'fqtk'){
+        ch_inputs = extract_csv_fqtk(ch_input)
 
-        ch_flowcells = ch_samplesheet
-            .branch { meta, samplesheet, flowcell, per_flowcell_manifest ->
-                tar: flowcell.toString().endsWith('.tar.gz')
+        ch_inputs.dump(tag: 'DEMULTIPLEX::inputs',{FormattingService.prettyFormat(it)})
+
+        // Split flowcells into separate channels containg run as tar and run as path
+        // https://nextflow.slack.com/archives/C02T98A23U7/p1650963988498929
+        ch_flowcells = ch_inputs
+            .branch { meta, samplesheet, run, manifest ->
+                tar: run.toString().endsWith('.tar.gz')
                 dir: true
             }
+
         ch_flowcells_tar = ch_flowcells.tar
-            .multiMap { meta, samplesheet, flowcell, per_flowcell_manifest ->
-                samplesheets: [ meta, samplesheet, per_flowcell_manifest ]
-                run_dirs: [ meta, flowcell ]
+            .multiMap { meta, samplesheet, run, manifest ->
+                samplesheets: [ meta, samplesheet, manifest ]
+                run_dirs: [ meta, run ]
             }
     } else {
+        ch_inputs = extract_csv(ch_input)
+        ch_inputs.dump(tag: 'DEMULTIPLEX::inputs',{FormattingService.prettyFormat(it)})
 
-        ch_flowcells = ch_samplesheet
-            .branch { meta, samplesheet, flowcell, per_flowcell_manifest ->
-                tar: flowcell.toString().endsWith('.tar.gz')
+        // Split flowcells into separate channels containg run as tar and run as path
+        // https://nextflow.slack.com/archives/C02T98A23U7/p1650963988498929
+        ch_flowcells = ch_inputs
+            .branch { meta, samplesheet, run ->
+                tar: run.toString().endsWith('.tar.gz')
                 dir: true
             }
+
         ch_flowcells_tar = ch_flowcells.tar
-            .multiMap { meta, samplesheet, flowcell, per_flowcell_manifest ->
+            .multiMap { meta, samplesheet, run ->
                 samplesheets: [ meta, samplesheet ]
-                run_dirs: [ meta, flowcell ]
+                run_dirs: [ meta, run ]
             }
     }
 
     // MODULE: untar
     // Runs when run_dir is a tar archive
-    // Except for bclconvert and bcl2fastq for which we untar in the process
+    // Except for bclconvert and bcl2fastq for wich we untar in the process
     // Re-join the metadata and the untarred run directory with the samplesheet
 
     if (demultiplexer in ['bclconvert', 'bcl2fastq']) ch_flowcells_tar_merged = ch_flowcells_tar.samplesheets.join(ch_flowcells_tar.run_dirs, failOnMismatch:true, failOnDuplicate:true)
@@ -113,7 +147,7 @@ workflow DEMULTIPLEX {
         case ['bcl2fastq', 'bclconvert']:
             // SUBWORKFLOW: illumina
             // Runs when "demultiplexer" is set to "bclconvert" or "bcl2fastq"
-            BCL_DEMULTIPLEX( ch_flowcells, demultiplexer, params.log_empty_fastqs )
+            BCL_DEMULTIPLEX( ch_flowcells, demultiplexer )
             ch_raw_fastq = ch_raw_fastq.mix( BCL_DEMULTIPLEX.out.fastq )
             ch_multiqc_files = ch_multiqc_files.mix( BCL_DEMULTIPLEX.out.reports.map { meta, report -> return report} )
             ch_multiqc_files = ch_multiqc_files.mix( BCL_DEMULTIPLEX.out.stats.map   { meta, stats  -> return stats } )
@@ -132,11 +166,11 @@ workflow DEMULTIPLEX {
             // [example_R1.fastq.gz, 150T, ./work/98/30bc..78y/fastqs/]
             fastqs_with_paths = fastq_read_structure.combine(UNTAR.out.untar.collect{it[1]}).toList()
 
-            // Format ch_samplesheet like so:
+            // Format ch_input like so:
             // [[meta:id], <path to sample names and barcodes in tsv: path>, [<fastq name: string>, <read structure: string>, <path to fastqs: path>]]]
-            ch_samplesheet = ch_flowcells.merge( fastqs_with_paths ) { a,b -> tuple(a[0], a[1], b)}
+            ch_input = ch_flowcells.merge( fastqs_with_paths ) { a,b -> tuple(a[0], a[1], b)}
 
-            FQTK_DEMULTIPLEX ( ch_samplesheet )
+            FQTK_DEMULTIPLEX ( ch_input )
             ch_raw_fastq = ch_raw_fastq.mix(FQTK_DEMULTIPLEX.out.fastq)
             ch_multiqc_files = ch_multiqc_files.mix(FQTK_DEMULTIPLEX.out.metrics.map { meta, metrics -> return metrics} )
             ch_versions = ch_versions.mix(FQTK_DEMULTIPLEX.out.versions)
@@ -179,53 +213,25 @@ workflow DEMULTIPLEX {
 
     // MODULE: md5sum
     // Split file list into separate channels entries and generate a checksum for each
-    if (!("md5sum" in skip_tools)){
-        MD5SUM(ch_fastq_to_qc.transpose())
-        ch_versions = ch_versions.mix(MD5SUM.out.versions)
-    }
+    MD5SUM(ch_fastq_to_qc.transpose())
 
-    //
-    // Collate and save software versions
-    //
-    softwareVersionsToYAML(ch_versions)
-        .collectFile(
-            storeDir: "${params.outdir}/pipeline_info",
-            name: 'nf_core_pipeline_software_mqc_versions.yml',
-            sort: true,
-            newLine: true
-        ).set { ch_collated_versions }
+    // DUMP SOFTWARE VERSIONS
+    CUSTOM_DUMPSOFTWAREVERSIONS (
+        ch_versions.unique().collectFile(name: 'collated_versions.yml')
+    )
 
     // MODULE: MultiQC
     if (!("multiqc" in skip_tools)){
-        ch_multiqc_files.collect().dump(tag: "multiqc_files",{FormattingService.prettyFormat(it)})
+        workflow_summary    = WorkflowDemultiplex.paramsSummaryMultiqc(workflow, summary_params)
+        ch_workflow_summary = Channel.value(workflow_summary)
 
-        ch_multiqc_config        = Channel.fromPath(
-            "$projectDir/assets/multiqc_config.yml", checkIfExists: true)
-        ch_multiqc_custom_config = params.multiqc_config ?
-            Channel.fromPath(params.multiqc_config, checkIfExists: true) :
-            Channel.empty()
-        ch_multiqc_logo= params.multiqc_logo ?
-            Channel.fromPath(params.multiqc_logo, checkIfExists: true) :
-            Channel.empty()
-        summary_params      = paramsSummaryMap(
-            workflow, parameters_schema: "nextflow_schema.json")
-        ch_workflow_summary = Channel.value(paramsSummaryMultiqc(summary_params))
+        methods_description    = WorkflowDemultiplex.methodsDescriptionText(workflow, ch_multiqc_custom_methods_description, params)
+        ch_methods_description = Channel.value(methods_description)
 
-        ch_multiqc_custom_methods_description = params.multiqc_methods_description ?
-            file(params.multiqc_methods_description, checkIfExists: true) :
-            file("$projectDir/assets/methods_description_template.yml", checkIfExists: true)
-        ch_methods_description                = Channel.value(
-            methodsDescriptionText(ch_multiqc_custom_methods_description))
-
-        ch_multiqc_files = ch_multiqc_files.mix(
-            ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
-        ch_multiqc_files = ch_multiqc_files.mix(ch_collated_versions)
-        ch_multiqc_files = ch_multiqc_files.mix(
-            ch_methods_description.collectFile(
-                name: 'methods_description_mqc.yaml',
-                sort: true
-            )
-        )
+        ch_multiqc_files = ch_multiqc_files.mix(ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
+        ch_multiqc_files = ch_multiqc_files.mix(ch_methods_description.collectFile(name: 'methods_description_mqc.yaml'))
+        ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
+        ch_multiqc_files.collect().dump(tag: "DEMULTIPLEX::MultiQC files",{FormattingService.prettyFormat(it)})
 
         MULTIQC (
             ch_multiqc_files.collect(),
@@ -233,13 +239,196 @@ workflow DEMULTIPLEX {
             ch_multiqc_custom_config.toList(),
             ch_multiqc_logo.toList()
         )
-        ch_multiqc_reports = ch_multiqc_reports.mix(MULTIQC.out.report)
+        multiqc_report = MULTIQC.out.report.toList()
+    }
+}
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    COMPLETION EMAIL AND SUMMARY
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+workflow.onComplete {
+    if (params.email || params.email_on_fail) {
+        NfcoreTemplate.email(workflow, params, summary_params, projectDir, log, multiqc_report)
+    }
+    NfcoreTemplate.dump_parameters(workflow, params)
+    NfcoreTemplate.summary(workflow, params, log)
+    if (params.hook_url) {
+        NfcoreTemplate.IM_notification(workflow, params, summary_params, projectDir, log)
+    }
+}
+
+workflow.onError {
+    if (workflow.errorReport.contains("Process requirement exceeds available memory")) {
+        println("🛑 Default resources exceed availability 🛑 ")
+        println("💡 See here on how to configure pipeline: https://nf-co.re/docs/usage/configuration#tuning-workflow-resources 💡")
+    }
+}
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    FUNCTIONS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+// Extract information (meta data + file(s)) from csv file(s)
+def extract_csv(input_csv, input_schema=null) {
+
+    // Flowcell Sheet schema
+    // Possible values for the "content" column: [meta, path, number, string, bool]
+    if(input_schema == null){
+        def default_input_schema = [
+            'columns': [
+                'id': [
+                    'content': 'meta',
+                    'meta_name': 'id',
+                    'pattern': '',
+                ],
+                'samplesheet': [
+                    'content': 'path',
+                    'pattern': '^.*.csv$',
+                ],
+                'lane': [
+                    'content': 'meta',
+                    'meta_name': 'lane',
+                    'pattern': '',
+                ],
+                'flowcell': [
+                    'content': 'path',
+                    'pattern': '',
+                ],
+            ],
+            required: ['id','flowcell', 'samplesheet'],
+        ]
+        input_schema = default_input_schema
+    }
+    // Don't change these variables
+    def row_count = 1
+    def all_columns = input_schema.columns.keySet().collect()
+    def mandatory_columns = input_schema.required
+
+    // Header checks
+    Channel.value(input_csv).splitCsv(strip:true).first().map({ row ->
+
+        if(row != all_columns) {
+            def commons = all_columns.intersect(row)
+            def diffs = all_columns.plus(row)
+            diffs.removeAll(commons)
+
+            if(diffs.size() > 0){
+                def missing_columns = []
+                def wrong_columns = []
+                for(diff : diffs){
+                    diff in all_columns ? missing_columns.add(diff) : wrong_columns.add(diff)
+                }
+                if(missing_columns.size() > 0){
+                    error "[Samplesheet Error] The column(s) $missing_columns is/are not present. The header should look like: $all_columns"
+                }
+                else {
+                    error "[Samplesheet Error] The column(s) $wrong_columns should not be in the header. The header should look like: $all_columns"
+                }
+            }
+            else {
+                error "[Samplesheet Error] The columns $row are not in the right order. The header should look like: $all_columns"
+            }
+
+        }
+    })
+
+    // Field checks + returning the channels
+    Channel.value(input_csv).splitCsv(header:true, strip:true).map({ row ->
+
+        row_count++
+
+        // Check the mandatory columns
+        def missing_mandatory_columns = []
+        for(column : mandatory_columns) {
+            row[column] ?: missing_mandatory_columns.add(column)
+        }
+        if(missing_mandatory_columns.size > 0){
+            error "[Samplesheet Error] The mandatory column(s) $missing_mandatory_columns is/are empty on line $row_count"
+        }
+
+        def output = []
+        def meta = [:]
+        for(col : input_schema.columns) {
+            key = col.key
+            content = row[key]
+
+            if(!(content ==~ col.value['pattern']) && col.value['pattern'] != '' && content != '') {
+                error "[Samplesheet Error] The content of column '$key' on line $row_count does not match the pattern '${col.value['pattern']}'"
+            }
+
+            if(col.value['content'] == 'path'){
+                output.add(content ? file(content, checkIfExists:true) : col.value['default'] ?: [])
+            }
+            else if(col.value['content'] == 'meta'){
+                for(meta_name : col.value['meta_name'].split(",")){
+                    meta[meta_name] = content != '' ? content.replace(' ', '_') : col.value['default'] ?: null
+                }
+            }
+        }
+
+        output.add(0, meta)
+        return output
+    })
+}
+
+// Parse flowcell input map
+def parse_flowcell_csv(row) {
+    def meta = [:]
+    meta.id   = row.id.toString()
+    meta.lane = null
+    if (row.containsKey("lane") && row.lane ) {
+        meta.lane = row.lane.toInteger()
     }
 
-    emit:
-    multiqc_report = ch_multiqc_reports // channel: /path/to/multiqc_report.html
-    versions       = ch_versions        // channel: [ path(versions.yml) ]
+    def flowcell        = file(row.flowcell, checkIfExists: true)
+    def samplesheet     = file(row.samplesheet, checkIfExists: true)
+    return [meta, samplesheet, flowcell]
+}
 
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    FUNCTIONS FOR FQTK
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+// Extract information (meta data + file(s)) from csv file(s)
+def extract_csv_fqtk(input_csv) {
+
+    // Flowcell Sheet schema
+    // Possible values for the "content" column: [meta, path, number, string, bool]
+    def input_schema = [
+        'columns': [
+            'id': [
+                'content': 'meta',
+                'meta_name': 'id',
+                'pattern': '',
+            ],
+            'samplesheet': [
+                'content': 'path',
+                'pattern': '^.*.csv$',
+            ],
+            'lane': [
+                'content': 'meta',
+                'meta_name': 'lane',
+                'pattern': '',
+            ],
+            'flowcell': [
+                'content': 'path',
+                'pattern': '',
+            ],
+            'per_flowcell_manifest': [
+                'content': 'path',
+                'pattern': '',
+            ]
+        ],
+        required: ['id','flowcell', 'samplesheet', 'per_flowcell_manifest'],
+    ]
+
+    return extract_csv(input_csv, input_schema)
 }
 
 /*


### PR DESCRIPTION
<!--
# nf-core/demultiplex pull request

Many thanks for contributing to nf-core/demultiplex!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/demultiplex/tree/master/.github/CONTRIBUTING.md)
-->

Closes https://github.com/nf-core/modules/issues/5612
nf-core/modules PR counterpart: https://github.com/nf-core/modules/pull/5638
## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/demultiplex/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/demultiplex _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

### Description

This pull request adds the optional parameter `--log_skipped_fastqs` to the `demultiplex` pipeline. This change was necessary to address the issue with logging skipped FASTQ files and preventing the AWS S3 issue.

### Patch Details

The changes in this PR were applied using a patch from a specific commit in the `nf-core/modules` repository. The commit details are as follows:

- **Commit:** [22bc6c5b186e16432e5b82d1932020b9c92e7040](https://github.com/nf-core/modules/commit/22bc6c5b186e16432e5b82d1932020b9c92e7040)
- **Patch File:** `git format-patch -1 22bc6c5b186e16432e5b82d1932020b9c92e7040 -o /<some_dir>/patch/ `

The patch was applied to ensure that the `demultiplex` repository includes the latest changes from `nf-core/modules` necessary for this feature.

### Testing
**true**
`nextflow run glichtenstein/demultiplex -r 7d9538e --input nf-core-samplesheet.csv --outdir /data/scratch/iseq-DI/output -profile docker -work-dir /data/scratch/iseq-DI/workdir -resume --skip_tools fastp --log_empty_fastqs=true`
 **false**
`nextflow run glichtenstein/demultiplex -r 7d9538e --input nf-core-samplesheet.csv --outdir /data/scratch/iseq-DI/output -profile docker -work-dir /data/scratch/iseq-DI/workdir -resume --skip_tools fastp --log_empty_fastqs=false`
  
executor >  local (5)
[1a/e1ae22] process > NFCORE_DEMULTIPLEX:DEMULTIPLEX:BCL_DEMULTIPLEX:BCLCONVERT  [100%] 1 of 1 ✔
[5f/05036f] process > NFCORE_DEMULTIPLEX:DEMULTIPLEX:FALCO (iseq-DI_S1_L001)                [100%] 1 of 1 ✔
[84/64923f] process > NFCORE_DEMULTIPLEX:DEMULTIPLEX:MD5SUM (iseq-DI_S1_L001)           [100%] 2 of 2 ✔
[11/351698] process > NFCORE_DEMULTIPLEX:DEMULTIPLEX:MULTIQC                                           [100%] 1 of 1 ✔
-[nf-core/demultiplex] Pipeline completed successfully-

`cat output/empty_fastqs.log `
Empty or invalid FASTQ file: /data/scratch/iseq-DI/workdir/1a/e1ae22.../Bad-iseq-DI_S2_L001_R1_001.fastq.gz
Empty or invalid FASTQ file: /data/scratch/iseq-DI/workdir/1a/e1ae22.../Bad-iseq-DI_S2_L001_R2_001.fastq.gz

### Dataset used
- A public BCL from 10X Genomics. I will add it to nf-core tests datasets when possible.
```
mkdir -p iseq-DI; cd iseq-DI
wget https://cf.10xgenomics.com/supp/spatial-exp/demultiplexing/iseq-DI.tar.gz
wget https://cf.10xgenomics.com/supp/spatial-exp/demultiplexing/bcl_convert_samplesheet.csv
```
SampleSheet was modified to include bad barcodes.

**nf-core_samplesheet.csv**
```
id,samplesheet,lane,flowcell,per_flowcell_manifest
AA0BCDFGH,/data/scratch/iseq-DI/bcl_convert_samplesheet.csv,1,/data/scratch/iseq-DI/iseq-DI.tar.gz
```
**bcl_convert_samplesheet.csv**
```
[Header],,,
FileFormatVersion,2,,
,,,
[BCLConvert_Settings],,,
CreateFastqForIndexReads,0,,
,,,
[BCLConvert_Data],,,
Lane,Sample_ID,index,index2
1,iseq-DI,GTAACATGCG,AGGTAACACT
1,Bad-iseq-DI,TATACAGATA,GATACAGATA
```