### PR TITLE
fix schema format path

### DIFF
--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -30,7 +30,7 @@
             },
             "flowcell": {
                 "type": "string",
-                "format": "file-path",
+                "format": "path",
                 "description": "Run directory"
             },
             "per_flowcell_manifest": {


### PR DESCRIPTION
This quick PR fixes the error:
`"* Entry 1 - flowcell: '/xxx/xxx' is not a file, but a directory (/xxx/xxx)"`

Potentially closes #191 

<!--
# nf-core/demultiplex pull request

Many thanks for contributing to nf-core/demultiplex!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/demultiplex/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/demultiplex/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/demultiplex _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
