### PR TITLE
Make samplesheet be published in outputdir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#214](https://github.com/nf-core/demultiplex/pull/214) Updated method for removing adapters from samplesheet, added custom AdapterRemover function.
 - [#210](https://github.com/nf-core/demultiplex/pull/212) Update bcl2fastq and bcl_demultiplex.
 - [#216](https://github.com/nf-core/demultiplex/pull/216) List fastq reports for R1 and R2 separately in multiqc report.
+- [#TBD](https://github.com/nf-core/demultiplex/pull/TBD) Modified workflow to store samplesheet in outdir/
 
 ## 1.4.1 - 2024-02-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#214](https://github.com/nf-core/demultiplex/pull/214) Updated method for removing adapters from samplesheet, added custom AdapterRemover function.
 - [#210](https://github.com/nf-core/demultiplex/pull/212) Update bcl2fastq and bcl_demultiplex.
 - [#216](https://github.com/nf-core/demultiplex/pull/216) List fastq reports for R1 and R2 separately in multiqc report.
-- [#TBD](https://github.com/nf-core/demultiplex/pull/TBD) Modified workflow to store samplesheet in outdir/
+- [#219](https://github.com/nf-core/demultiplex/pull/219) Modified workflow to store samplesheet in results folder.
 
 ## 1.4.1 - 2024-02-27
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -193,11 +193,11 @@ Creates an MD5 (128-bit) checksum of every fastq.
 <details markdown="1">
 <summary>Output files</summary>
 
-- `<Samplesheet_name>_no_adapters.csv`
+- `<meta.id>.csv`
 
 </details>
 
-This is done by a custom function in the workflow, not by a module. Creates an updated samplesheet from the input by removing the adapter sequence within the "\[Settings\]" section.
+This is done by a custom function in the workflow, not by a module. Creates an updated samplesheet from the input by removing the adapter sequence within the "\[Settings\]" section. If the samplesheet doesn't require any adapter removal, it will still be published in the specified output folder.
 
 ### MultiQC
 

--- a/workflows/demultiplex.nf
+++ b/workflows/demultiplex.nf
@@ -70,6 +70,11 @@ workflow DEMULTIPLEX {
         .map{ id,meta,flowcell,lane,samplesheet -> [meta,samplesheet,flowcell,lane]}
 
         ch_samplesheet = ch_samplesheet_new
+    } else {
+        ch_samplesheet
+            .collectFile( storeDir: "${params.outdir}" ){ item ->
+                [ "${item[0].id}.csv", item[1] ]
+            }
     }
 
     // Convenience


### PR DESCRIPTION
<!--
# nf-core/demultiplex pull request

Many thanks for contributing to nf-core/demultiplex!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/demultiplex/tree/master/.github/CONTRIBUTING.md)
-->

This PR addresses this issue:
https://github.com/nf-core/demultiplex/issues/215

Samplesheet for samples that require adapter trimming are already being published into outputdir, added some lines to make the rest of the samplesheets to be published too. Updated the docs too.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/demultiplex/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/demultiplex _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
