### PR TITLE
Change samplesheet to point to trimmed fastqs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Changed`
 
 - [#334](https://github.com/nf-core/demultiplex/pull/334) Template update for nf-core/tools v3.3.2
+- [#335](https://github.com/nf-core/demultiplex/pull/335) Generated samplesheets now point to trimmed fastq files when they exist.
 
 ### `Fixed`
+
+- [#334](https://github.com/nf-core/demultiplex/pull/334) Template update for nf-core/tools v3.3.2
+- [#335](https://github.com/nf-core/demultiplex/pull/335) Samplesheet generation no longer has a tag (was previously every fastq file name)
 
 ### `Dependencies`
 

--- a/modules/local/fastq_to_samplesheet/main.nf
+++ b/modules/local/fastq_to_samplesheet/main.nf
@@ -1,5 +1,4 @@
 process FASTQ_TO_SAMPLESHEET {
-    tag "$meta.id"
 
     executor 'local'
     memory 100.MB

--- a/workflows/demultiplex.nf
+++ b/workflows/demultiplex.nf
@@ -270,14 +270,16 @@ workflow DEMULTIPLEX {
     }
 
     // Prepare metamap with fastq info
-    ch_meta_fastq = ch_raw_fastq.map { meta, fastq_files ->
+    ch_meta_fastq = ch_fastq_to_qc.map { meta, fastq_files ->
         // Determine the publish directory based on the lane information
         meta.publish_dir = meta.lane ? "${params.outdir}/${meta.fcid}/L00${meta.lane}" : "${params.outdir}/${meta.fcid}" //Must be fcid because id gets modified
-        meta.fastq_1 = "${meta.publish_dir}/${fastq_files[0].getName()}"
 
         // Add full path for fastq_2 to the metadata if the sample is not single-end
         if (!meta.single_end) {
+            meta.fastq_1 = "${meta.publish_dir}/${fastq_files[0].getName()}"
             meta.fastq_2 = "${meta.publish_dir}/${fastq_files[1].getName()}"
+        } else {
+            meta.fastq_1 = "${meta.publish_dir}/${fastq_files.getName()}"
         }
         return meta
     }


### PR DESCRIPTION
Currently the generated samplesheets only point to the original fastq files, not the trimmed ones.
This PR changes that to make sure that they .
I've also removed the tag for the samplesheet generation, as it is currently `[sample1, sample2, sample3, sample4, ...]` which isn't particularly helpful. 