### PR TITLE
Add index files to workflow outputs

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -138,7 +138,7 @@ output {
         index {
             path 'demultiplexed_fastq.csv'
         }
-        
+
     }
     demultiplex_reports {
         path { meta, report ->
@@ -235,7 +235,7 @@ output {
         index {
             path 'fastq_idx.csv'
         }
-        
+
     }
     undetermined {
         enabled params.optional_outputs

--- a/main.nf
+++ b/main.nf
@@ -135,6 +135,10 @@ output {
                 f >> "${lane_dir}/${f.name}"
             }
         }
+        index {
+            path 'demultiplexed_fastq.csv'
+        }
+        
     }
     demultiplex_reports {
         path { meta, report ->
@@ -144,6 +148,9 @@ output {
                 f >> "${lane_dir}/${f.name}"
             }
         }
+        index {
+            path 'demultiplex_reports.csv'
+        }
     }
     demultiplex_interop {
         path { meta, interop ->
@@ -152,17 +159,26 @@ output {
                 f >> "${meta.id}/InterOp/${f.name}"
             }
         }
+        index {
+            path 'demultiplex_interop.csv'
+        }
     }
     demultiplex_stats {
         path { meta, stat ->
             def lane_dir = meta.lane ? "${meta.id}/L00${meta.lane}" : "${meta.id}"
             "${lane_dir}/${stat.name}"
         }
+        index {
+            path 'demultiplex_stats.csv'
+        }
     }
     demultiplex_logs {
         path { meta, log ->
             def lane_dir = meta.lane ? "${meta.id}/L00${meta.lane}" : "${meta.id}"
             "${lane_dir}/${log.name}"
+        }
+        index {
+            path 'demultiplex_logs.csv'
         }
     }
     pipeline_samplesheets {
@@ -176,11 +192,17 @@ output {
             def lane_dir = meta.lane ? "${meta.id}/L00${meta.lane}" : "${meta.id}"
             "${lane_dir}/"
         }
+        index {
+            path 'checkqc_reports.csv'
+        }
     }
     fastp_reports {
         path { meta, _report ->
             def lane_dir = meta.lane ? "${meta.fcid}/L00${meta.lane}" : "${meta.fcid}"
             "${lane_dir}/"
+        }
+        index {
+            path 'fastp_reports.csv'
         }
     }
     falco_reports {
@@ -188,11 +210,17 @@ output {
             def lane_dir = meta.lane ? "${meta.fcid}/L00${meta.lane}" : "${meta.fcid}"
             "${lane_dir}/"
         }
+        index {
+            path 'falco_reports.csv'
+        }
     }
     md5_checksums {
         path { meta, _checksum ->
             def lane_dir = meta.lane ? "${meta.fcid}/L00${meta.lane}" : "${meta.fcid}"
             "${lane_dir}/"
+        }
+        index {
+            path 'md5_checksums.csv'
         }
     }
     fastq_idx {
@@ -204,6 +232,10 @@ output {
                 f >> "${lane_dir}/${f.name}"
             }
         }
+        index {
+            path 'fastq_idx.csv'
+        }
+        
     }
     undetermined {
         enabled params.optional_outputs
@@ -214,6 +246,9 @@ output {
                 f >> "${lane_dir}/${f.name}"
             }
         }
+        index {
+            path 'undetermined.csv'
+        }
     }
     undetermined_idx {
         enabled params.optional_outputs
@@ -223,6 +258,9 @@ output {
             files.each { f ->
                 f >> "${lane_dir}/${f.name}"
             }
+        }
+        index {
+            path 'undetermined_idx.csv'
         }
     }
     multiqcsav_report {

--- a/main.nf
+++ b/main.nf
@@ -110,7 +110,7 @@ workflow {
 
     publish:
     demultiplexed_fastq   = NFCORE_DEMULTIPLEX.out.demultiplexed_fastq.transpose()
-    demultiplex_reports   = NFCORE_DEMULTIPLEX.out.demultiplex_reports
+    demultiplex_reports   = NFCORE_DEMULTIPLEX.out.demultiplex_reports.transpose()
     demultiplex_interop   = NFCORE_DEMULTIPLEX.out.demultiplex_interop.transpose()
     demultiplex_stats     = NFCORE_DEMULTIPLEX.out.demultiplex_stats
     demultiplex_logs      = NFCORE_DEMULTIPLEX.out.demultiplex_logs

--- a/main.nf
+++ b/main.nf
@@ -109,9 +109,9 @@ workflow {
     )
 
     publish:
-    demultiplexed_fastq   = NFCORE_DEMULTIPLEX.out.demultiplexed_fastq
+    demultiplexed_fastq   = NFCORE_DEMULTIPLEX.out.demultiplexed_fastq.transpose()
     demultiplex_reports   = NFCORE_DEMULTIPLEX.out.demultiplex_reports
-    demultiplex_interop   = NFCORE_DEMULTIPLEX.out.demultiplex_interop
+    demultiplex_interop   = NFCORE_DEMULTIPLEX.out.demultiplex_interop.transpose()
     demultiplex_stats     = NFCORE_DEMULTIPLEX.out.demultiplex_stats
     demultiplex_logs      = NFCORE_DEMULTIPLEX.out.demultiplex_logs
     pipeline_samplesheets = NFCORE_DEMULTIPLEX.out.pipeline_samplesheets
@@ -120,20 +120,16 @@ workflow {
     fastp_reports         = NFCORE_DEMULTIPLEX.out.fastp_reports
     falco_reports         = NFCORE_DEMULTIPLEX.out.falco_reports
     md5_checksums         = NFCORE_DEMULTIPLEX.out.md5_checksums
-    fastq_idx             = NFCORE_DEMULTIPLEX.out.fastq_idx
-    undetermined          = NFCORE_DEMULTIPLEX.out.undetermined
-    undetermined_idx      = NFCORE_DEMULTIPLEX.out.undetermined_idx
+    fastq_idx             = NFCORE_DEMULTIPLEX.out.fastq_idx.transpose()
+    undetermined          = NFCORE_DEMULTIPLEX.out.undetermined.transpose()
+    undetermined_idx      = NFCORE_DEMULTIPLEX.out.undetermined_idx.transpose()
     multiqcsav_report     = NFCORE_DEMULTIPLEX.out.multiqcsav_report
 }
 
 output {
     demultiplexed_fastq {
         path { meta, fastq ->
-            def lane_dir = meta.lane ? "${meta.fcid}/L00${meta.lane}" : "${meta.fcid}"
-            def files = fastq instanceof List ? new ArrayList(fastq) : [fastq]
-            files.each { f ->
-                f >> "${lane_dir}/${f.name}"
-            }
+            fastq >> (meta.lane ? "${meta.fcid}/L00${meta.lane}/${fastq.name}" : "${meta.fcid}/${fastq.name}")
         }
         index {
             path 'demultiplexed_fastq.csv'
@@ -142,11 +138,7 @@ output {
     }
     demultiplex_reports {
         path { meta, report ->
-            def lane_dir = meta.lane ? "${meta.id}/L00${meta.lane}" : "${meta.id}"
-            def files = report instanceof List ? new ArrayList(report) : [report]
-            files.each { f ->
-                f >> "${lane_dir}/${f.name}"
-            }
+            report >> (meta.lane ? "${meta.id}/L00${meta.lane}/${report.name}" : "${meta.id}/${report.name}")
         }
         index {
             path 'demultiplex_reports.csv'
@@ -154,10 +146,7 @@ output {
     }
     demultiplex_interop {
         path { meta, interop ->
-            def files = interop instanceof List ? new ArrayList(interop) : [interop]
-            files.each { f ->
-                f >> "${meta.id}/InterOp/${f.name}"
-            }
+            interop >> "${meta.id}/InterOp/${interop.name}"
         }
         index {
             path 'demultiplex_interop.csv'
@@ -225,12 +214,7 @@ output {
     }
     fastq_idx {
         path { meta, fastq ->
-            def id = meta.fcid ?: meta.id
-            def lane_dir = meta.lane ? "${id}/L00${meta.lane}" : "${id}"
-            def files = fastq instanceof List ? new ArrayList(fastq) : [fastq]
-            files.each { f ->
-                f >> "${lane_dir}/${f.name}"
-            }
+            fastq >> (meta.lane ? "${meta.fcid ?: meta.id}/L00${meta.lane}/${fastq.name}" : "${meta.fcid ?: meta.id}/${fastq.name}")
         }
         index {
             path 'fastq_idx.csv'
@@ -240,11 +224,7 @@ output {
     undetermined {
         enabled params.optional_outputs
         path { meta, fastq ->
-            def lane_dir = meta.lane ? "${meta.id}/L00${meta.lane}/undetermined" : "${meta.id}/undetermined"
-            def files = fastq instanceof List ? new ArrayList(fastq) : [fastq]
-            files.each { f ->
-                f >> "${lane_dir}/${f.name}"
-            }
+            fastq >> (meta.lane ? "${meta.id}/L00${meta.lane}/undetermined/${fastq.name}" : "${meta.id}/undetermined/${fastq.name}")
         }
         index {
             path 'undetermined.csv'
@@ -253,11 +233,7 @@ output {
     undetermined_idx {
         enabled params.optional_outputs
         path { meta, fastq ->
-            def lane_dir = meta.lane ? "${meta.id}/L00${meta.lane}/undetermined" : "${meta.id}/undetermined"
-            def files = fastq instanceof List ? new ArrayList(fastq) : [fastq]
-            files.each { f ->
-                f >> "${lane_dir}/${f.name}"
-            }
+            fastq >> (meta.lane ? "${meta.id}/L00${meta.lane}/undetermined/${fastq.name}" : "${meta.id}/undetermined/${fastq.name}")
         }
         index {
             path 'undetermined_idx.csv'

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -45,3 +45,15 @@ multiqcsav/multiqc_data/multiqc_software_versions.txt
 multiqcsav/multiqc_data/multiqc_sources.txt
 multiqcsav/multiqc_data/llms-full.txt
 multiqcsav/multiqc_data/bcl2fastq_undetermined.txt
+checkqc_reports.csv
+demultiplex_interop.csv
+demultiplex_logs.csv
+demultiplex_reports.csv
+demultiplex_stats.csv
+demultiplexed_fastq.csv
+falco_reports.csv
+fastp_reports.csv
+fastq_idx.csv
+md5_checksums.csv
+undetermined.csv
+undetermined_idx.csv

--- a/tests/bcl2fastq.nf.test.snap
+++ b/tests/bcl2fastq.nf.test.snap
@@ -72,6 +72,16 @@
                 "220422_M11111_0222_000000000-K9H97/L001/Stats/output/Stats/DemuxSummaryF1L1.txt",
                 "220422_M11111_0222_000000000-K9H97/L001/Stats/output/Stats/FastqSummaryF1L1.txt",
                 "220422_M11111_0222_000000000-K9H97/L001/Stats/output/Stats/Stats.json",
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/bcl2fastq-lane-stats-table.txt",
@@ -282,10 +292,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-06T15:20:05.388036959",
+        "timestamp": "2026-07-30T13:29:50.02062689",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/bclconvert.nf.test.snap
+++ b/tests/bclconvert.nf.test.snap
@@ -54,6 +54,16 @@
                 "220422_M11111_0222_000000000-K9H97/L001/Sample1_S1_L001_report.html",
                 "220422_M11111_0222_000000000-K9H97/L001/Sample1_S1_L001_summary.txt",
                 "220422_M11111_0222_000000000-K9H97/L001/Undetermined_S0_L001_R1_001.fastq.gz",
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/bclconvert-lane-stats-table.txt",
@@ -282,10 +292,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-06T15:22:24.895172688",
+        "timestamp": "2026-07-30T13:31:39.805164302",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/bclconvert_mini.nf.test.snap
+++ b/tests/bclconvert_mini.nf.test.snap
@@ -20,6 +20,16 @@
                 }
             },
             [
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "miniseq_truseq_smrna",
                 "miniseq_truseq_smrna/HBRR1_S1_L001.fastp.fastq.gz",
                 "miniseq_truseq_smrna/HBRR1_S1_L001.fastp.fastq.gz.md5",
@@ -273,7 +283,9 @@
                 "samplesheet/methylseq_samplesheet.csv",
                 "samplesheet/rnaseq_samplesheet.csv",
                 "samplesheet/sarek_samplesheet.csv",
-                "samplesheet/taxprofiler_samplesheet.csv"
+                "samplesheet/taxprofiler_samplesheet.csv",
+                "undetermined.csv",
+                "undetermined_idx.csv"
             ],
             [
                 "HBRR1_S1_L001.fastp.fastq.gz:md5,451657490d4816dd5ff904e34ecc7fdf",
@@ -412,10 +424,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-06T15:14:17.278303718",
+        "timestamp": "2026-07-30T13:35:52.869654973",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -20,6 +20,16 @@
                 }
             },
             [
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/falco-status-check-heatmap.txt",
@@ -222,10 +232,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-06T15:26:42.172512262",
+        "timestamp": "2026-07-30T13:18:58.771530173",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/flowcell.nf.test.snap
+++ b/tests/flowcell.nf.test.snap
@@ -20,6 +20,16 @@
                 }
             },
             [
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/falco-status-check-heatmap.txt",
@@ -578,10 +588,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-06T15:30:07.35611885",
+        "timestamp": "2026-07-30T13:44:05.897942435",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Test single-flowcell input - BCLCONVERT": {
@@ -605,6 +615,16 @@
                 }
             },
             [
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "miniseq_truseq_smrna",
                 "miniseq_truseq_smrna/HBRR1_S1_L001.fastp.fastq.gz",
                 "miniseq_truseq_smrna/HBRR1_S1_L001.fastp.fastq.gz.md5",
@@ -994,10 +1014,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-06T15:34:53.145512802",
+        "timestamp": "2026-07-30T13:50:15.901833281",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Test single-flowcell input - BASES2FASTQ": {
@@ -1021,6 +1041,16 @@
                 }
             },
             [
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/falco-status-check-heatmap.txt",
@@ -1223,10 +1253,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-06T15:31:35.708949346",
+        "timestamp": "2026-07-30T13:46:04.634583013",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Test single-flowcell input - FQTK": {
@@ -1250,6 +1280,16 @@
                 }
             },
             [
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/falco-status-check-heatmap.txt",
@@ -2045,10 +2085,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-06T15:37:44.285520288",
+        "timestamp": "2026-07-30T13:53:55.502554169",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Fails with both --input and --flowcell_samplesheet": {
@@ -2139,6 +2179,16 @@
                 "220422_M11111_0222_000000000-K9H97/L001/Stats/DemuxSummaryF1L1.txt",
                 "220422_M11111_0222_000000000-K9H97/L001/Stats/FastqSummaryF1L1.txt",
                 "220422_M11111_0222_000000000-K9H97/L001/Stats/Stats.json",
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/bcl2fastq-lane-stats-table.txt",
@@ -2349,10 +2399,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-06T15:28:33.672534178",
+        "timestamp": "2026-07-30T13:40:49.764888558",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/fqtk.nf.test.snap
+++ b/tests/fqtk.nf.test.snap
@@ -20,6 +20,16 @@
                 }
             },
             [
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/falco-status-check-heatmap.txt",
@@ -815,10 +825,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-06T15:42:33.839178983",
+        "timestamp": "2026-07-30T13:57:43.611870683",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/kraken.nf.test.snap
+++ b/tests/kraken.nf.test.snap
@@ -85,6 +85,16 @@
                 "Sample1_S1_L001",
                 "Sample1_S1_L001/L001",
                 "Sample1_S1_L001/L001/Sample1_S1_L001.kraken2.report.txt",
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/bcl2fastq-lane-stats-table.txt",
@@ -307,10 +317,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-06T15:44:34.581793862",
+        "timestamp": "2026-07-30T14:00:04.15827515",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/mgikit.nf.test.snap
+++ b/tests/mgikit.nf.test.snap
@@ -20,6 +20,7 @@
                 "checkqc_reports.csv",
                 "demultiplex_interop.csv",
                 "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
                 "demultiplex_stats.csv",
                 "demultiplexed_fastq.csv",
                 "falco_reports.csv",
@@ -156,6 +157,11 @@
                 "test-fc01",
                 "test-fc01.csv",
                 "test-fc01/L001",
+                "test-fc01/L001/FC01.L01.mgikit.general",
+                "test-fc01/L001/FC01.L01.mgikit.info",
+                "test-fc01/L001/FC01.L01.mgikit.sample_stats",
+                "test-fc01/L001/FC01.L01.mgikit.undetermined_barcode",
+                "test-fc01/L001/FC01.L01.mgikit.undetermined_barcode.complete",
                 "test-fc01/L001/Sample01.fastp.html",
                 "test-fc01/L001/Sample01.fastp.json",
                 "test-fc01/L001/Sample01_R1.fastp.fastq.gz",
@@ -240,6 +246,11 @@
                 "fastp_filtered_reads_plot.txt:md5,da422dd1adcd26e9cc89d97b832d8304",
                 "multiqc_citations.txt:md5,d35df50e9903a96a2b3bce3c1fbc8ad2",
                 "test-fc01.csv:md5,74dfac5602f25fe428510a500d3b4700",
+                "FC01.L01.mgikit.general:md5,624b0d43c3995fde2c122c447e780191",
+                "FC01.L01.mgikit.info:md5,69a72a1c43d47032828d8b97c6cf8807",
+                "FC01.L01.mgikit.sample_stats:md5,20d5b9f4a430fd34579e0f70b42f73f0",
+                "FC01.L01.mgikit.undetermined_barcode:md5,c1960b64d4cc5c141d742aa1b6f57a31",
+                "FC01.L01.mgikit.undetermined_barcode.complete:md5,c1960b64d4cc5c141d742aa1b6f57a31",
                 "Sample01.fastp.json:md5,e3e0d82b0697e466e4f4bd229b86f0b0",
                 "Sample01_R1.fastp.fastq.gz:md5,19752026de713f514637fab29e4ffac4",
                 "Sample01_R1.fastp.fastq.gz.md5:md5,b6ff9581e39892552e62112ed03ae1a7",
@@ -286,7 +297,7 @@
                 "Sample04_S4_L01_R2_001.fastq.gz:md5,cd88081007614f5bed7975b04e25b7e3"
             ]
         ],
-        "timestamp": "2026-07-30T14:01:19.310844856",
+        "timestamp": "2026-07-30T18:55:54.409665781",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.0"

--- a/tests/mgikit.nf.test.snap
+++ b/tests/mgikit.nf.test.snap
@@ -17,6 +17,15 @@
                 }
             },
             [
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/falco-status-check-heatmap.txt",
@@ -147,11 +156,6 @@
                 "test-fc01",
                 "test-fc01.csv",
                 "test-fc01/L001",
-                "test-fc01/L001/FC01.L01.mgikit.general",
-                "test-fc01/L001/FC01.L01.mgikit.info",
-                "test-fc01/L001/FC01.L01.mgikit.sample_stats",
-                "test-fc01/L001/FC01.L01.mgikit.undetermined_barcode",
-                "test-fc01/L001/FC01.L01.mgikit.undetermined_barcode.complete",
                 "test-fc01/L001/Sample01.fastp.html",
                 "test-fc01/L001/Sample01.fastp.json",
                 "test-fc01/L001/Sample01_R1.fastp.fastq.gz",
@@ -236,11 +240,6 @@
                 "fastp_filtered_reads_plot.txt:md5,da422dd1adcd26e9cc89d97b832d8304",
                 "multiqc_citations.txt:md5,d35df50e9903a96a2b3bce3c1fbc8ad2",
                 "test-fc01.csv:md5,74dfac5602f25fe428510a500d3b4700",
-                "FC01.L01.mgikit.general:md5,624b0d43c3995fde2c122c447e780191",
-                "FC01.L01.mgikit.info:md5,69a72a1c43d47032828d8b97c6cf8807",
-                "FC01.L01.mgikit.sample_stats:md5,20d5b9f4a430fd34579e0f70b42f73f0",
-                "FC01.L01.mgikit.undetermined_barcode:md5,c1960b64d4cc5c141d742aa1b6f57a31",
-                "FC01.L01.mgikit.undetermined_barcode.complete:md5,c1960b64d4cc5c141d742aa1b6f57a31",
                 "Sample01.fastp.json:md5,e3e0d82b0697e466e4f4bd229b86f0b0",
                 "Sample01_R1.fastp.fastq.gz:md5,19752026de713f514637fab29e4ffac4",
                 "Sample01_R1.fastp.fastq.gz.md5:md5,b6ff9581e39892552e62112ed03ae1a7",
@@ -287,10 +286,10 @@
                 "Sample04_S4_L01_R2_001.fastq.gz:md5,cd88081007614f5bed7975b04e25b7e3"
             ]
         ],
-        "timestamp": "2026-07-06T15:45:43.205266793",
+        "timestamp": "2026-07-30T14:01:19.310844856",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/mkfastq.nf.test.snap
+++ b/tests/mkfastq.nf.test.snap
@@ -85,6 +85,16 @@
                 "cellranger-tiny-bcl-simple/L001/test_sample_S1_L001_R2.fastp.fastq.gz_fastqc_report.html",
                 "cellranger-tiny-bcl-simple/L001/test_sample_S1_L001_R2.fastp.fastq.gz_summary.txt",
                 "cellranger-tiny-bcl-simple/L001/test_sample_S1_L001_R2_001.fastq.gz",
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/falco-status-check-heatmap.txt",
@@ -275,10 +285,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-06T15:47:01.80490067",
+        "timestamp": "2026-07-31T19:08:02.995502733",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/tests/sgdemux.nf.test.snap
+++ b/tests/sgdemux.nf.test.snap
@@ -20,6 +20,16 @@
                 }
             },
             [
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/falco-status-check-heatmap.txt",
@@ -578,10 +588,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-06T15:49:29.518771976",
+        "timestamp": "2026-07-30T16:07:56.742651669",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/skip_tools.nf.test.snap
+++ b/tests/skip_tools.nf.test.snap
@@ -48,6 +48,16 @@
                 "220422_M11111_0222_000000000-K9H97/L001/Sample1_S1_L001_report.html",
                 "220422_M11111_0222_000000000-K9H97/L001/Sample1_S1_L001_summary.txt",
                 "220422_M11111_0222_000000000-K9H97/L001/Undetermined_S0_L001_R1_001.fastq.gz",
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/bclconvert-lane-stats-table.txt",
@@ -213,10 +223,10 @@
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f"
             ]
         ],
-        "timestamp": "2026-07-06T15:51:19.073974804",
+        "timestamp": "2026-07-30T16:09:47.948200738",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Skip Trimming": {
@@ -268,6 +278,16 @@
                 "220422_M11111_0222_000000000-K9H97/L001/Sample1_S1_L001_report.html",
                 "220422_M11111_0222_000000000-K9H97/L001/Sample1_S1_L001_summary.txt",
                 "220422_M11111_0222_000000000-K9H97/L001/Undetermined_S0_L001_R1_001.fastq.gz",
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/bclconvert-lane-stats-table.txt",
@@ -455,10 +475,10 @@
                 ]
             ]
         ],
-        "timestamp": "2026-07-06T15:50:28.24933946",
+        "timestamp": "2026-07-30T16:08:52.793881693",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Skip MultiQC": {
@@ -516,6 +536,16 @@
                 "220422_M11111_0222_000000000-K9H97/L001/Sample1_S1_L001_report.html",
                 "220422_M11111_0222_000000000-K9H97/L001/Sample1_S1_L001_summary.txt",
                 "220422_M11111_0222_000000000-K9H97/L001/Undetermined_S0_L001_R1_001.fastq.gz",
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "multiqcsav",
                 "multiqcsav/multiqc_data",
                 "multiqcsav/multiqc_data/bclconvert-lane-stats-table.txt",
@@ -580,10 +610,10 @@
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f"
             ]
         ],
-        "timestamp": "2026-07-06T15:55:24.739244533",
+        "timestamp": "2026-07-30T16:14:26.540155636",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Skip Fastqc": {
@@ -641,6 +671,16 @@
                 "220422_M11111_0222_000000000-K9H97/L001/Sample1_S1_L001_report.html",
                 "220422_M11111_0222_000000000-K9H97/L001/Sample1_S1_L001_summary.txt",
                 "220422_M11111_0222_000000000-K9H97/L001/Undetermined_S0_L001_R1_001.fastq.gz",
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/bclconvert-lane-stats-table.txt",
@@ -847,10 +887,10 @@
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f"
             ]
         ],
-        "timestamp": "2026-07-06T15:53:07.310717321",
+        "timestamp": "2026-07-30T16:11:40.378744096",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     },
     "Skip Fastp & Fastqc": {
@@ -902,6 +942,16 @@
                 "220422_M11111_0222_000000000-K9H97/L001/Sample1_S1_L001_report.html",
                 "220422_M11111_0222_000000000-K9H97/L001/Sample1_S1_L001_summary.txt",
                 "220422_M11111_0222_000000000-K9H97/L001/Undetermined_S0_L001_R1_001.fastq.gz",
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/bclconvert-lane-stats-table.txt",
@@ -1067,10 +1117,10 @@
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f"
             ]
         ],
-        "timestamp": "2026-07-06T15:53:57.569818391",
+        "timestamp": "2026-07-30T16:12:43.486127625",
         "meta": {
             "nf-test": "0.9.5",
-            "nextflow": "25.10.4"
+            "nextflow": "26.04.0"
         }
     }
 }

--- a/tests/trimming/remove_samplesheet_adapter/main.nf.test.snap
+++ b/tests/trimming/remove_samplesheet_adapter/main.nf.test.snap
@@ -17,6 +17,16 @@
                 }
             },
             [
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/bclconvert-lane-stats-table.txt",
@@ -260,11 +270,11 @@
                 "Undetermined_S0_L001_R1_001.fastq.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
+        "timestamp": "2026-07-30T16:17:29.819222648",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-04-07T17:32:27.150122684"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     },
     "User wants to trim with the demultiplexer": {
         "content": [
@@ -281,6 +291,16 @@
                 }
             },
             [
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/bclconvert-lane-stats-table.txt",
@@ -474,11 +494,11 @@
                 "Undetermined_S0_L001_R1_001.fastq.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
+        "timestamp": "2026-07-30T16:18:39.028875475",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-03-19T18:04:28.174784875"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     },
     "User wants to skip trimming all together": {
         "content": [
@@ -495,6 +515,16 @@
                 }
             },
             [
+                "checkqc_reports.csv",
+                "demultiplex_interop.csv",
+                "demultiplex_logs.csv",
+                "demultiplex_reports.csv",
+                "demultiplex_stats.csv",
+                "demultiplexed_fastq.csv",
+                "falco_reports.csv",
+                "fastp_reports.csv",
+                "fastq_idx.csv",
+                "md5_checksums.csv",
                 "multiqc",
                 "multiqc/multiqc_data",
                 "multiqc/multiqc_data/bclconvert-lane-stats-table.txt",
@@ -688,10 +718,10 @@
                 "Undetermined_S0_L001_R1_001.fastq.gz:md5,d41d8cd98f00b204e9800998ecf8427e"
             ]
         ],
+        "timestamp": "2026-07-30T16:19:52.287860921",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.3"
-        },
-        "timestamp": "2026-03-19T18:05:05.455201812"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     }
 }

--- a/workflows/demultiplex.nf
+++ b/workflows/demultiplex.nf
@@ -274,7 +274,12 @@ workflow DEMULTIPLEX {
         ch_raw_fastq = ch_raw_fastq.mix(generateFastqMeta(MGIKIT_DEMULTIPLEX.out.fastq, /_S\d+_L0\d+_R\d+.*$/, 'ELEMENT', true))
         ch_undetermined = ch_undetermined.mix(MGIKIT_DEMULTIPLEX.out.undetermined)
         ch_multiqc_files = ch_multiqc_files.mix(MGIKIT_DEMULTIPLEX.out.qc_reports.map { _meta, metrics -> metrics })
-        ch_demultiplex_reports = ch_demultiplex_reports.mix(MGIKIT_DEMULTIPLEX.out.qc_reports).mix(MGIKIT_DEMULTIPLEX.out.sample_stat_reports).mix(MGIKIT_DEMULTIPLEX.out.undetermined_reports).mix(MGIKIT_DEMULTIPLEX.out.undetermined_reports)
+        ch_demultiplex_reports = ch_demultiplex_reports
+            .mix(MGIKIT_DEMULTIPLEX.out.general_info_reports)
+            .mix(MGIKIT_DEMULTIPLEX.out.index_reports)
+            .mix(MGIKIT_DEMULTIPLEX.out.sample_stat_reports)
+            .mix(MGIKIT_DEMULTIPLEX.out.undetermined_reports)
+            .mix(MGIKIT_DEMULTIPLEX.out.ambiguous_reports)
     }
     else {
         error("Unknown demultiplexer: ${demultiplexer}")
@@ -334,7 +339,7 @@ workflow DEMULTIPLEX {
         def files_list = fastq_files instanceof List ? fastq_files : [fastq_files]
 
         // Determine the publish directory based on the lane information
-        def publish_dir = meta.lane ? "${params.outdir}/${meta.fcid}/L00${meta.lane}" : "${params.outdir}/${meta.fcid}"
+        def publish_dir = meta.lane ? "${outdir}/${meta.fcid}/L00${meta.lane}" : "${outdir}/${meta.fcid}"
 
         // Add full path for fastq files to the metadata
         def meta_out = meta + [


### PR DESCRIPTION
Closes https://github.com/nf-core/demultiplex/issues/403

This PR adds [index files](https://docs.seqera.io/nextflow/workflow#index-files) to workflow outputs which is useful for provenance reporting. This PR also tidies the way workflow outputs are written. 

(Note: This does not enable https://github.com/nf-core/datasync/issues/63 yet as the output from `md5_checksums` does not have the required structure by datasync).