### PR TITLE
Update bcl_demultiplex subworkflow and multiqcsav module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#409](https://github.com/nf-core/demultiplex/pull/409) Update bclconvert and multiqcsav
 - [#410](https://github.com/nf-core/demultiplex/pull/410) Template update for nf-core/tools v4.1.0
 - [#411](https://github.com/nf-core/demultiplex/pull/411) Replace FASTQ_TO_SAMPLESHEET process with CHANNEL_FASTQ_CREATE_CSV subworkflow using channel operators
+- [#417](https://github.com/nf-core/demultiplex/pull/417) Update bcl_demultiplex subworkflow and multiqcsav module
 
 ### `Fixed`
 

--- a/modules.json
+++ b/modules.json
@@ -67,7 +67,7 @@
                     },
                     "multiqcsav": {
                         "branch": "master",
-                        "git_sha": "98403d15b0e50edae1f3fec5eae5e24982f1fade",
+                        "git_sha": "6ef220fd9252b42fb3c50348bbdbcb6246730686",
                         "installed_by": ["bcl_demultiplex"]
                     },
                     "samshee": {
@@ -96,7 +96,7 @@
                 "nf-core": {
                     "bcl_demultiplex": {
                         "branch": "master",
-                        "git_sha": "8b798ea24b2d639ef4d204add9ddb35dc0d8279f",
+                        "git_sha": "c5d82c0d48f39025e56264b572575255f77847bc",
                         "installed_by": ["subworkflows"]
                     },
                     "fastq_contam_seqtk_kraken": {

--- a/modules/nf-core/multiqcsav/meta.yml
+++ b/modules/nf-core/multiqcsav/meta.yml
@@ -112,16 +112,6 @@ output:
       - multiqc --version | sed "s/.* //g":
           type: eval
           description: The expression to obtain the version of the tool
-  versions_interop:
-    - - ${task.process}:
-          type: string
-          description: The process the versions were collected from
-      - interop:
-          type: string
-          description: The tool name
-      - python -c "import interop; print(interop.__version__)":
-          type: eval
-          description: The expression to obtain the version of the tool
   versions_multiqcsav:
     - - ${task.process}:
           type: string
@@ -130,6 +120,16 @@ output:
           type: string
           description: The name of the tool
       - python -c "import multiqc_sav; print(multiqc_sav.__version__)":
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_interop:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - interop:
+          type: string
+          description: The tool name
+      - python -c "import interop; print(interop.__version__)":
           type: eval
           description: The expression to obtain the version of the tool
 authors:

--- a/subworkflows/nf-core/bcl_demultiplex/main.nf
+++ b/subworkflows/nf-core/bcl_demultiplex/main.nf
@@ -103,34 +103,42 @@ def generateReadgroupBCLCONVERT(ch_fastq_list_csv, ch_fastq) {
     return ch_fastq_list_csv
         .join(ch_fastq, by: [0])
         .map { meta, csv_file, fastq_list ->
-            def fastq_files = fastq_list instanceof List ? fastq_list : [fastq_list]
-            def meta_fastq = []
-            csv_file
-                .splitCsv(header: true)
-                .each { row ->
-                    // Create the readgroup tuple
-                    // RGID,RGSM,RGLB,Lane,Read1File,Read2File
-                    def rg = [:]
-                    // row.RGID is index1.index2.lane
-                    rg.ID = row.RGID
-                    // RGPU is a custom column in the samplesheet containing the flowcell ID
-                    rg.PU = row.RGPU ? row.RGPU : meta.id + "." + row.Lane
-                    rg.SM = row.RGSM
-                    rg.LB = row.RGLB ? row.RGLB : ""
-                    rg.PL = "ILLUMINA"
-
-                    // dereference the fastq files in the csv
-                    def fastq1 = fastq_files.find { fq -> file(fq).name == file(row.Read1File).name }
-                    def fastq2 = row.Read2File ? fastq_files.find { fq -> file(fq).name == file(row.Read2File).name } : null
-
-                    // set fastq metadata
-                    def new_meta = meta + [id: fastq1.getSimpleName().toString() - ~/_R[0-9]_001.*$/, readgroup: rg, single_end: !fastq2]
-
-                    meta_fastq << [new_meta, fastq2 ? [fastq1, fastq2] : [fastq1]]
-                }
-            return meta_fastq
+            return createReadgroupBCLCONVERT(meta, csv_file, fastq_list)
         }
         .flatMap()
+}
+
+def createReadgroupBCLCONVERT(meta, csv_file, fastq_list) {
+    def fastq_files = fastq_list instanceof List ? fastq_list : [fastq_list]
+    def emitted_fastq = [] as Set
+    def meta_fastq = []
+    csv_file
+        .splitCsv(header: true)
+        .each { row ->
+            // dereference the fastq files in the csv
+            def fastq1 = fastq_files.find { fq -> file(fq).name == file(row.Read1File).name }
+            def fastq2 = row.Read2File ? fastq_files.find { fq -> file(fq).name == file(row.Read2File).name } : null
+            def fastq_key = [fastq1, fastq2].findAll().collect { fq -> file(fq).name }.join("|")
+
+            if (emitted_fastq.add(fastq_key)) {
+                // Create the readgroup tuple
+                // RGID,RGSM,RGLB,Lane,Read1File,Read2File
+                def rg = [:]
+                // row.RGID is index1.index2.lane
+                rg.ID = row.RGID
+                // RGPU is a custom column in the samplesheet containing the flowcell ID
+                rg.PU = row.RGPU ? row.RGPU : meta.id + "." + row.Lane
+                rg.SM = row.RGSM
+                rg.LB = row.RGLB ? row.RGLB : ""
+                rg.PL = "ILLUMINA"
+
+                // set fastq metadata
+                def new_meta = meta + [id: fastq1.getSimpleName().toString() - ~/_R[0-9]_001.*$/, readgroup: rg, single_end: !fastq2]
+
+                meta_fastq << [new_meta, fastq2 ? [fastq1, fastq2] : [fastq1]]
+            }
+        }
+    return meta_fastq
 }
 
 def generateReadgroupBCL2FASTQ(ch_fastq) {

--- a/subworkflows/nf-core/bcl_demultiplex/meta.yml
+++ b/subworkflows/nf-core/bcl_demultiplex/meta.yml
@@ -12,51 +12,93 @@ components:
   - bclconvert
   - multiqcsav
 input:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'string', lane: int ]
-  - samplesheet:
+  - ch_flowcell:
       type: file
       description: |
-        CSV file containing information about samples to be demultiplexed in Illumina SampleSheet format
-  - flowcell:
-      type: file
-      description: Directory or tar archive containing Illumina BCL data, sequencer output directory
+        Channel containing the Illumina SampleSheet CSV describing the samples to be
+        demultiplexed, together with the directory or tar archive holding the Illumina
+        BCL data (the sequencer output directory). The meta map carries the flowcell
+        identifier and lane, e.g. [ id:'string', lane: int ].
+
+        Structure: [ val(meta), path(samplesheet), path(flowcell) ]
   - demultiplexer:
       type: string
       description: Which demultiplexer to use, bcl2fastq or bclconvert
+
 output:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test' ]
   - fastq:
       type: file
-      description: Demultiplexed fastq files
+      description: |
+        Demultiplexed FASTQ files, with read group information added to the meta map.
+        Samples whose FASTQ files are empty are routed to `empty_fastq` instead.
+
+        Structure: [ val(meta), [ path(fastq) ] ]
+      pattern: "*.fastq.gz"
+  - empty_fastq:
+      type: file
+      description: |
+        Demultiplexed FASTQ files that contain no reads, separated out so that
+        downstream processes do not have to handle them.
+
+        Structure: [ val(meta), [ path(fastq) ] ]
       pattern: "*.fastq.gz"
   - reports:
       type: file
-      description: Demultiplexing reports
+      description: |
+        Demultiplexing reports.
+
+        Structure: [ val(meta), path(reports) ]
       pattern: "Reports/*"
-  - interop:
-      type: file
-      description: InterOp files
-      pattern: "InterOp/*"
   - stats:
       type: file
-      description: Demultiplexing statistics (bcl2fastq only)
+      description: |
+        Demultiplexing statistics (bcl2fastq only).
+
+        Structure: [ val(meta), path(stats) ]
       pattern: "Stats/*"
+  - interop:
+      type: file
+      description: |
+        InterOp files.
+
+        Structure: [ val(meta), path(interop) ]
+      pattern: "InterOp/*"
   - logs:
       type: file
-      description: Demultiplexing logs (bclconvert only)
+      description: |
+        Demultiplexing logs (bclconvert only).
+
+        Structure: [ val(meta), path(logs) ]
       pattern: "Logs/*"
-  - versions:
+  - undetermined:
       type: file
-      description: File containing software versions
-      pattern: "versions.yml"
+      description: |
+        FASTQ files holding the reads that could not be assigned to any sample.
+
+        Structure: [ val(meta), [ path(fastq) ] ]
+      pattern: "Undetermined_S0*_R?_00?.fastq.gz"
+  - sav_report:
+      type: file
+      description: |
+        MultiQC report summarising the sequencing analysis viewer (SAV) metrics for
+        the flowcell.
+
+        Structure: [ val(meta), path(html) ]
+      pattern: "*.html"
+  - sav_data:
+      type: directory
+      description: |
+        MultiQC data directory for the SAV report.
+
+        Structure: [ val(meta), path(data) ]
+      pattern: "*_data"
+  - sav_plots:
+      type: file
+      description: |
+        Plots created by MultiQC for the SAV report.
+
+        Structure: [ val(meta), path(plots) ]
+      pattern: "*_plots"
 authors:
   - "@matthdsm"
 maintainers:


### PR DESCRIPTION
Update bcl_demultiplex subworkflow and multiqcsav module from upstream:

- bcl_demultiplex: extract createReadgroupBCLCONVERT as standalone function, deduplicate FASTQ entries across CSV rows, expand meta.yml documentation
- multiqcsav: reorder version output sections in meta.yml
- modules.json: bump tracked git SHAs

Generated by opencode
Verified by @maxulysse 